### PR TITLE
Limit electron languages to English

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -50,3 +50,5 @@ publish:
   url: https://github.com/nexmoe/vidbee/releases/latest/download
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/
+electronLanguages:
+  - en


### PR DESCRIPTION
Restricts electron language downloads to English only to reduce package size.\n