### PR TITLE
fix(update): streamline update notification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 3. Support i18n, only translate the English version of en.json
 4. use English for comments&console
 5. Follow the ✅ KISS (Keep It Simple, Stupid) & ✅ YAGNI (You Aren't Gonna Need It) principles
+6. Use Conventional Commits format for commit messages: `type(scope): subject`. Common types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert. PR titles should also follow this format.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -317,9 +317,7 @@ function initAutoUpdater(): void {
 
       if (mainWindow) {
         mainWindow.webContents.send('update:show-notification', {
-          title: 'Update Ready',
-          body: `Version ${info.version} has been downloaded and will be installed on restart.`,
-          icon: 'app-icon'
+          version: info.version
         })
       }
     })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -168,34 +168,14 @@ function AppContent() {
       return
     }
 
-    const showRestartPrompt = () => {
-      toast.info(t('about.notifications.restartToUpdate'), {
-        action: {
-          label: t('about.notifications.restartNowAction'),
-          onClick: () => {
-            void ipcServices.update.quitAndInstall()
-          }
-        }
-      })
-    }
-
     const resetDownloadState = () => {
       if (updateDownloadInProgressRef.current) {
         updateDownloadInProgressRef.current = false
       }
     }
 
-    const handleUpdateDownloaded = (rawInfo: unknown) => {
-      const info = (rawInfo ?? {}) as { version?: string }
+    const handleUpdateDownloaded = (_rawInfo: unknown) => {
       resetDownloadState()
-
-      const versionLabel = info?.version ?? ''
-      const downloadedMessage = versionLabel
-        ? t('about.notifications.updateDownloadedVersion', { version: versionLabel })
-        : t('about.notifications.updateDownloaded')
-      toast.success(downloadedMessage)
-
-      showRestartPrompt()
     }
 
     const handleUpdateError = (rawMessage: unknown) => {
@@ -214,13 +194,13 @@ function AppContent() {
     }
 
     const handleUpdateNotification = (rawPayload: unknown) => {
-      const payload = (rawPayload ?? {}) as { body?: string; version?: string }
-      const versionLabel = payload.version ?? ''
+      const payload = (rawPayload ?? {}) as { version?: string }
+      const versionLabel = payload?.version ?? ''
       const downloadedMessage = versionLabel
         ? t('about.notifications.updateDownloadedVersion', { version: versionLabel })
         : t('about.notifications.updateDownloaded')
 
-      toast.info(payload?.body ?? downloadedMessage, {
+      toast.info(downloadedMessage, {
         action: {
           label: t('about.notifications.restartNowAction'),
           onClick: () => {


### PR DESCRIPTION
Streamline update notifications by sending only version metadata. Simplifies renderer handling for download events.