### PR TITLE
fix(download): restore downloads for Twitch and Twitter

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "cp $CONDUCTOR_ROOT_PATH/resources/ resources/ &&  pnpm install",
+    "setup": "cp -r $CONDUCTOR_ROOT_PATH/resources resources/ && pnpm install",
     "run": "pnpm run dev"
   }
 }

--- a/src/main/download-engine/args-builder.ts
+++ b/src/main/download-engine/args-builder.ts
@@ -21,6 +21,10 @@ export const resolveVideoFormatSelector = (options: DownloadOptions): string => 
   const format = options.format
   const audioFormat = options.audioFormat
 
+  if (format && audioFormat === '') {
+    return format
+  }
+
   if (format && (format.includes('/') || (audioFormat === undefined && format.includes('+')))) {
     return format
   }

--- a/src/renderer/src/components/download/DownloadDialog.tsx
+++ b/src/renderer/src/components/download/DownloadDialog.tsx
@@ -114,9 +114,11 @@ const buildVideoFormatPreference = (settings: AppSettings): string => {
       combinations.push(video)
     }
   } else {
-    // Use bestvideo+bestaudio as fallback instead of 'best' to ensure merging
+    // Prefer merged formats, then allow 'best' as a compatibility fallback.
     combinations.push('bestvideo+bestaudio')
   }
+
+  combinations.push('best')
 
   return dedupe(combinations).join('/')
 }
@@ -935,28 +937,32 @@ export function DownloadDialog({ onOpenSupportedSites, onOpenSettings }: Downloa
                       {t('sites.viewAll')}
                     </Button>
                   </div>
-
-                  {settings.oneClickDownload && (
-                    <div className="flex items-center gap-2 text-xs text-primary">
-                      <div className="w-1.5 h-1.5 rounded-full bg-primary" />
-                      <span>{t('download.oneClickDownloadEnabled')}</span>
-                      {onOpenSettings && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-xs h-auto"
-                          onClick={() => {
-                            setOpen(false)
-                            onOpenSettings()
-                          }}
-                        >
-                          {t('download.goToSettings')}
-                        </Button>
-                      )}
-                    </div>
-                  )}
                 </div>
+
+                {/* One-click download indicator */}
+                {settings.oneClickDownload && (
+                  <div className="w-full">
+                    <div className="rounded-lg border bg-muted/30 p-2.5">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{t('download.oneClickDownloadEnabled')}</span>
+                        {onOpenSettings && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs h-auto"
+                            onClick={() => {
+                              setOpen(false)
+                              onOpenSettings()
+                            }}
+                          >
+                            {t('download.goToSettings')}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
 
                 {/* Error Display */}
                 {error && (


### PR DESCRIPTION
Fix format selection fallbacks so platforms like Twitch and Twitter can download again, even when only HLS or combined formats are present. Allow video downloads to proceed without forcing an audio merge and add a final best fallback for one-click/playlist downloads. Also refines the one-click indicator layout and Conductor setup script. Tests: pnpm run check.