### PR TITLE
fix(download): handle empty format selections

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "cp -r $CONDUCTOR_ROOT_PATH/resources resources && pnpm install",
+    "setup": "rm -rf resources && cp -r $CONDUCTOR_ROOT_PATH/resources resources && pnpm install",
     "run": "pnpm run dev"
   }
 }

--- a/src/main/lib/download-engine.ts
+++ b/src/main/lib/download-engine.ts
@@ -36,6 +36,19 @@ interface DownloadProcess {
   process: YTDlpEventEmitter
 }
 
+const formatYtDlpCommand = (args: string[]): string => {
+  const quoted = args.map((arg) => {
+    if (arg === '') {
+      return '""'
+    }
+    if (/[\s"'\\]/.test(arg)) {
+      return `"${arg.replace(/(["\\])/g, '\\$1')}"`
+    }
+    return arg
+  })
+  return `yt-dlp ${quoted.join(' ')}`
+}
+
 const ensureDirectoryExists = (dir?: string): void => {
   if (!dir) {
     return
@@ -731,6 +744,8 @@ class DownloadEngine extends EventEmitter {
 
     args.push('--ffmpeg-location', ffmpegPath)
     args.push(urlArg)
+
+    scopedLoggers.download.info('yt-dlp command:', formatYtDlpCommand(args))
 
     const controller = new AbortController()
     const ytdlpProcess = ytdlp.exec(args, {

--- a/src/renderer/src/components/download/DownloadDialog.tsx
+++ b/src/renderer/src/components/download/DownloadDialog.tsx
@@ -790,11 +790,12 @@ export function DownloadDialog({ onOpenSupportedSites, onOpenSettings }: Downloa
         type,
         format:
           type === 'video'
-            ? videoInfoCardState.selectedVideoFormat
+            ? videoInfoCardState.selectedVideoFormat || undefined
             : type === 'extract'
               ? undefined
-              : videoInfoCardState.selectedAudioFormat,
-        audioFormat: type === 'video' ? videoInfoCardState.selectedAudioForVideo : undefined,
+              : videoInfoCardState.selectedAudioFormat || undefined,
+        audioFormat:
+          type === 'video' ? videoInfoCardState.selectedAudioForVideo || undefined : undefined,
         extractFormat:
           type === 'extract' ? videoInfoCardState.audioExtractor.extractFormat : undefined,
         extractQuality:


### PR DESCRIPTION
Fixes empty format fallbacks so video+audio selection defaults correctly and avoids silent downloads. Also logs the resolved yt-dlp command and hides empty quality selectors. Updates Conductor setup to replace resources before install.