### PR TITLE
fix(settings): merge defaults for getAll

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -53,7 +53,11 @@ class SettingsManager {
   }
 
   getAll(): AppSettings {
-    return this.store.store
+    return {
+      ...defaultSettings,
+      downloadPath: DEFAULT_DOWNLOAD_PATH,
+      ...this.store.store
+    }
   }
 
   setAll(settings: Partial<AppSettings>): void {


### PR DESCRIPTION
Merge default settings into getAll output so missing keys are filled.
This avoids undefined values from older installs breaking advanced settings.

closes #61