### PR TITLE
chore(build): reduce packaged artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
           $source = Join-Path 'ffmpeg' '${{ matrix.ffmpeg_inner_path }}'
           $destination = Join-Path 'resources' '${{ matrix.ffmpeg_output }}'
           Copy-Item -Path $source -Destination $destination -Force
+          Remove-Item ffmpeg.zip -Force
+          Remove-Item ffmpeg -Recurse -Force
 
       - name: Download ffmpeg binary (macOS)
         if: matrix.platform == 'macos'
@@ -112,6 +114,7 @@ jobs:
           tar -xf ffmpeg.tar.xz -C ffmpeg
           cp "ffmpeg/${{ matrix.ffmpeg_inner_path }}" "resources/${{ matrix.ffmpeg_output }}"
           chmod +x "resources/${{ matrix.ffmpeg_output }}"
+          rm -rf ffmpeg.tar.xz ffmpeg
 
       - name: Download yt-dlp binary
         shell: bash

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -8,11 +8,16 @@ protocols:
       - vidbee
 files:
   - '!**/.vscode/*'
+  - '!**/.context/**'
+  - '!**/.github/**'
   - '!src/*'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
   - '!{.eslintcache,eslint.config.mjs,dev-app-update.yml,CHANGELOG.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+  - '!extension/**'
+  - '!monkey/**'
+  - '!screenshots/**'
 asarUnpack:
   - resources/**
 win:


### PR DESCRIPTION
Reduce release bundle size by cleaning temporary ffmpeg downloads and excluding non-runtime folders from packaging. This keeps CI/CD artifacts leaner without changing runtime behavior.