### PR TITLE
fix(update): localize update toast

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -364,12 +364,6 @@ function initAutoUpdater(): void {
     autoUpdater.on('update-downloaded', (info) => {
       log.info('Update downloaded:', info.version)
       mainWindow?.webContents.send('update:downloaded', info)
-
-      if (mainWindow) {
-        mainWindow.webContents.send('update:show-notification', {
-          version: info.version
-        })
-      }
     })
 
     log.info('Auto-updater initialized successfully')

--- a/src/renderer/src/pages/About.tsx
+++ b/src/renderer/src/pages/About.tsx
@@ -39,7 +39,7 @@ type LatestVersionState =
   | null
 
 export function About() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [settings, _setSettings] = useAtom(settingsAtom)
   const [updateReady] = useAtom(updateReadyAtom)
   const setUpdateAvailable = useSetAtom(updateAvailableAtom)
@@ -81,7 +81,7 @@ export function About() {
       const versionLabel = info.version ?? ''
 
       // Update will be downloaded automatically because autoDownload is enabled in main process
-      toast.success(t('about.notifications.updateAvailable', { version: versionLabel }))
+      toast.success(i18n.t('about.notifications.updateAvailable', { version: versionLabel }))
       setLatestVersionState({
         status: 'available',
         version: versionLabel
@@ -115,7 +115,7 @@ export function About() {
       ipcEvents.removeListener('update:download-progress', handleUpdateDownloadProgress)
       ipcEvents.removeListener('update:downloaded', handleUpdateDownloaded)
     }
-  }, [setUpdateAvailable, t])
+  }, [i18n, setUpdateAvailable])
 
   const handleSettingChange = async (
     key: keyof typeof settings,


### PR DESCRIPTION
Remove the extra update notification event and render the toast from the renderer with the active locale. This keeps a single toast that matches the current language.