### PR TITLE
build(mac): sign bundled tools

### DIFF
--- a/build/after-sign.cjs
+++ b/build/after-sign.cjs
@@ -1,0 +1,58 @@
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const BINARIES = ['yt-dlp_macos', 'ffmpeg_macos', 'deno']
+
+const findAppBundle = (appOutDir) => {
+  const entries = fs.readdirSync(appOutDir)
+  const app = entries.find((entry) => entry.endsWith('.app'))
+  return app ? path.join(appOutDir, app) : null
+}
+
+const resolveSigningIdentity = () =>
+  process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY || '-'
+
+const signBinary = (targetPath, entitlementsPath) => {
+  const identity = resolveSigningIdentity()
+  const args = ['--force', '--sign', identity, '--entitlements', entitlementsPath]
+
+  if (identity !== '-') {
+    args.push('--options', 'runtime', '--timestamp')
+  }
+
+  args.push(targetPath)
+  execFileSync('codesign', args, { stdio: 'inherit' })
+}
+
+exports.default = async function afterSign(context) {
+  if (context.electronPlatformName !== 'darwin') {
+    return
+  }
+
+  const appBundle = findAppBundle(context.appOutDir)
+  if (!appBundle) {
+    console.warn('afterSign: No .app bundle found, skipping yt-dlp signing.')
+    return
+  }
+
+  const resourcesPath = path.join(
+    appBundle,
+    'Contents',
+    'Resources',
+    'app.asar.unpacked',
+    'resources'
+  )
+
+  const entitlementsPath = path.resolve(__dirname, 'entitlements.mac.plist')
+
+  for (const binary of BINARIES) {
+    const targetPath = path.join(resourcesPath, binary)
+    if (!fs.existsSync(targetPath)) {
+      console.warn(`afterSign: Missing ${binary}, skipping.`)
+      continue
+    }
+    console.log(`afterSign: Signing ${binary} with entitlements.`)
+    signBinary(targetPath, entitlementsPath)
+  }
+}

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,6 +2,7 @@ appId: com.vidbee
 productName: VidBee
 directories:
   buildResources: build
+afterSign: build/after-sign.cjs
 protocols:
   - name: VidBee
     schemes:


### PR DESCRIPTION
Add an afterSign hook to re-sign bundled yt-dlp, ffmpeg, and deno with app entitlements on macOS. Include disable-library-validation in the mac entitlements so yt-dlp can load its embedded Python framework. Ran pnpm run check.