### PR TITLE
fix(renderer): disable text selection

### DIFF
--- a/src/renderer/src/assets/global.css
+++ b/src/renderer/src/assets/global.css
@@ -8,11 +8,16 @@
     @apply border-border;
   }
   body {
-    @apply text-foreground;
+    @apply text-foreground select-none;
+  }
+  input,
+  textarea,
+  [contenteditable='true'],
+  [contenteditable=''] {
+    @apply select-text;
   }
   input::placeholder,
   textarea::placeholder {
     opacity: 0.4;
   }
 }
-


### PR DESCRIPTION
Prevents text selection across the UI by default and keeps selection enabled for inputs and contenteditable fields. This aligns with the requested interaction behavior.