### PR TITLE
fix(settings): disable embed thumbnail by default

### DIFF
--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -298,7 +298,7 @@ export const defaultSettings: AppSettings = {
   subscriptionOnlyLatestDefault: true,
   enableAnalytics: true,
   embedSubs: true,
-  embedThumbnail: true,
+  embedThumbnail: false,
   embedMetadata: true,
   embedChapters: true
 }


### PR DESCRIPTION
Disable embed thumbnail in default settings so new installs keep it off by default. Existing users keep their stored preference.