### PR TITLE
fix(settings): avoid auto-creating download folder

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -20,9 +20,7 @@ const ensureDirectoryExists = (dir: string) => {
 }
 
 const resolveDefaultDownloadPath = () => {
-  const downloadDir = path.join(os.homedir(), 'Downloads', 'VidBee')
-  ensureDirectoryExists(downloadDir)
-  return downloadDir
+  return path.join(os.homedir(), 'Downloads', 'VidBee')
 }
 
 const DEFAULT_DOWNLOAD_PATH = resolveDefaultDownloadPath()
@@ -75,7 +73,6 @@ class SettingsManager {
       ...defaultSettings,
       downloadPath: DEFAULT_DOWNLOAD_PATH
     })
-    ensureDirectoryExists(DEFAULT_DOWNLOAD_PATH)
   }
 
   private ensureDownloadDirectory(): void {
@@ -88,7 +85,6 @@ class SettingsManager {
       if (normalizedDownloadPath !== currentPath) {
         this.store.set('downloadPath', normalizedDownloadPath)
       }
-      ensureDirectoryExists(normalizedDownloadPath)
     } catch (error) {
       scopedLoggers.system.error('Failed to verify download directory:', error)
     }

--- a/src/renderer/src/components/download/SingleVideoDownload.tsx
+++ b/src/renderer/src/components/download/SingleVideoDownload.tsx
@@ -17,12 +17,9 @@ import { useAtom } from 'jotai'
 import { AlertCircle, ExternalLink, Loader2, Settings2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  DOWNLOAD_FEEDBACK_ISSUE_TITLE,
-  FeedbackLinkButtons
-} from '../feedback/FeedbackLinks'
 import { useCachedThumbnail } from '../../hooks/use-cached-thumbnail'
 import { settingsAtom } from '../../store/settings'
+import { DOWNLOAD_FEEDBACK_ISSUE_TITLE, FeedbackLinkButtons } from '../feedback/FeedbackLinks'
 
 export interface SingleVideoState {
   title: string


### PR DESCRIPTION
Stops eager creation of the default Downloads/VidBee folder during settings initialization. The folder is now created when a download starts or when the user sets a custom path.