### PR TITLE
fix(subscriptions): prevent duplicate RSS feeds

### DIFF
--- a/src/renderer/src/locales/ar.json
+++ b/src/renderer/src/locales/ar.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "هذا الفيديو موجود بالفعل في قائمة الانتظار",
       "queueError": "فشل في الإضافة إلى قائمة انتظار التحميل.",
       "openLinkError": "فشل في فتح رابط الفيديو.",
-      "resolveError": "فشل في حل رابط تغذية RSS."
+      "resolveError": "فشل في حل رابط تغذية RSS.",
+      "duplicateUrl": "تم الاشتراك في موجز RSS هذا بالفعل."
     },
     "detectedFeed": "تم اكتشاف تغذية {{platform}} -> {{feed}}",
     "detecting": "جاري اكتشاف التغذية...",

--- a/src/renderer/src/locales/de.json
+++ b/src/renderer/src/locales/de.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Dieses Video ist bereits in der Warteschlange",
       "queueError": "Hinzufügen zur Download-Warteschlange fehlgeschlagen.",
       "openLinkError": "Video-Link konnte nicht geöffnet werden.",
-      "resolveError": "RSS-Feed-URL konnte nicht aufgelöst werden."
+      "resolveError": "RSS-Feed-URL konnte nicht aufgelöst werden.",
+      "duplicateUrl": "Dieser RSS-Feed ist bereits abonniert."
     },
     "detectedFeed": "{{platform}} Feed erkannt -> {{feed}}",
     "detecting": "Feed wird erkannt...",

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -538,6 +538,7 @@
       "missingUrl": "Please paste a channel link first.",
       "created": "Subscription added",
       "createError": "Failed to add subscription.",
+      "duplicateUrl": "This RSS feed is already subscribed.",
       "refreshStarted": "Refresh started",
       "removed": "Subscription removed",
       "updated": "Subscription updated",

--- a/src/renderer/src/locales/es.json
+++ b/src/renderer/src/locales/es.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Este video ya está en cola",
       "queueError": "Error al agregar a la cola de descarga.",
       "openLinkError": "Error al abrir el enlace del video.",
-      "resolveError": "Error al resolver la URL del feed RSS."
+      "resolveError": "Error al resolver la URL del feed RSS.",
+      "duplicateUrl": "Este feed RSS ya está suscrito."
     },
     "detectedFeed": "Feed {{platform}} detectado -> {{feed}}",
     "detecting": "Detectando feed...",

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Cette vidéo est déjà en file d'attente",
       "queueError": "Échec de l'ajout à la file d'attente de téléchargement.",
       "openLinkError": "Échec de l'ouverture du lien vidéo.",
-      "resolveError": "Échec de la résolution de l'URL du flux RSS."
+      "resolveError": "Échec de la résolution de l'URL du flux RSS.",
+      "duplicateUrl": "Ce flux RSS est déjà abonné."
     },
     "detectedFeed": "Flux {{platform}} détecté -> {{feed}}",
     "detecting": "Détection du flux...",

--- a/src/renderer/src/locales/id.json
+++ b/src/renderer/src/locales/id.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Video ini sudah diantre",
       "queueError": "Gagal menambahkan ke antrian unduhan.",
       "openLinkError": "Gagal membuka tautan video.",
-      "resolveError": "Gagal menyelesaikan URL feed RSS."
+      "resolveError": "Gagal menyelesaikan URL feed RSS.",
+      "duplicateUrl": "Feed RSS ini sudah berlangganan."
     },
     "detectedFeed": "Feed {{platform}} terdeteksi -> {{feed}}",
     "detecting": "Mendeteksi feed...",

--- a/src/renderer/src/locales/it.json
+++ b/src/renderer/src/locales/it.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Questo video è già in coda",
       "queueError": "Impossibile aggiungere alla coda di download.",
       "openLinkError": "Impossibile aprire il collegamento video.",
-      "resolveError": "Impossibile risolvere l'URL del feed RSS."
+      "resolveError": "Impossibile risolvere l'URL del feed RSS.",
+      "duplicateUrl": "Questo feed RSS è già sottoscritto."
     },
     "detectedFeed": "Feed {{platform}} rilevato -> {{feed}}",
     "detecting": "Rilevamento alimentazione...",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "このビデオはすでにキューに登録されています",
       "queueError": "ダウンロードキューへの追加に失敗しました。",
       "openLinkError": "ビデオリンクを開けませんでした。",
-      "resolveError": "RSS フィード URL を解決できませんでした。"
+      "resolveError": "RSS フィード URL を解決できませんでした。",
+      "duplicateUrl": "このRSSフィードはすでに登録されています。"
     },
     "detectedFeed": "{{platform}} フィードが検出されました -> {{feed}}",
     "detecting": "フィードを検出中...",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "이 동영상은 이미 대기열에 있습니다.",
       "queueError": "다운로드 대기열에 추가하지 못했습니다.",
       "openLinkError": "동영상 링크를 열지 못했습니다.",
-      "resolveError": "RSS 피드 URL을 확인하지 못했습니다."
+      "resolveError": "RSS 피드 URL을 확인하지 못했습니다.",
+      "duplicateUrl": "이 RSS 피드는 이미 구독되어 있습니다."
     },
     "detectedFeed": "{{platform}} 피드 감지됨 -> {{feed}}",
     "detecting": "피드 감지 중...",

--- a/src/renderer/src/locales/pt.json
+++ b/src/renderer/src/locales/pt.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Este vídeo já está na fila",
       "queueError": "Falha ao adicionar à fila de download.",
       "openLinkError": "Falha ao abrir o link do vídeo.",
-      "resolveError": "Falha ao resolver o URL do feed RSS."
+      "resolveError": "Falha ao resolver o URL do feed RSS.",
+      "duplicateUrl": "Este feed RSS já está inscrito."
     },
     "detectedFeed": "Feed de {{platform}} detectado -> {{feed}}",
     "detecting": "Detectando feed...",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "Это видео уже в очереди",
       "queueError": "Не удалось добавить в очередь загрузки.",
       "openLinkError": "Не удалось открыть ссылку на видео.",
-      "resolveError": "Не удалось разрешить URL RSS-канала."
+      "resolveError": "Не удалось разрешить URL RSS-канала.",
+      "duplicateUrl": "Этот RSS-канал уже добавлен."
     },
     "detectedFeed": "Обнаружен канал {{platform}} -> {{feed}}",
     "detecting": "Определение канала...",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "該視頻已排隊",
       "queueError": "無法添加到下載隊列。",
       "openLinkError": "無法打開視頻鏈接。",
-      "resolveError": "無法解析 RSS 源 URL。"
+      "resolveError": "無法解析 RSS 源 URL。",
+      "duplicateUrl": "此 RSS 訂閱已存在。"
     },
     "detectedFeed": "檢測到 {{platform}} feed -> {{feed}}",
     "detecting": "檢測飼料...",

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -545,7 +545,8 @@
       "itemAlreadyQueued": "该视频已排队",
       "queueError": "无法添加到下载队列。",
       "openLinkError": "无法打开视频链接。",
-      "resolveError": "无法解析 RSS 源 URL。"
+      "resolveError": "无法解析 RSS 源 URL。",
+      "duplicateUrl": "该 RSS 订阅已存在。"
     },
     "detectedFeed": "检测到 {{platform}} feed -> {{feed}}",
     "detecting": "检测饲料...",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -200,6 +200,8 @@ export type SubscriptionPlatform = 'youtube' | 'bilibili' | 'custom'
 
 export type SubscriptionStatus = 'idle' | 'checking' | 'up-to-date' | 'failed'
 
+export const SUBSCRIPTION_DUPLICATE_FEED_ERROR = 'SUBSCRIPTION_DUPLICATE_FEED_URL'
+
 export interface SubscriptionRule {
   id: string
   title: string


### PR DESCRIPTION
Detect duplicate RSS feed URLs on create/update and show a specific duplicate toast. Adds feed normalization in the manager and i18n strings for the new message.