### PR TITLE
feat(feedback): warn on long github issue urls

### DIFF
--- a/src/renderer/src/locales/ar.json
+++ b/src/renderer/src/locales/ar.json
@@ -197,7 +197,8 @@
       "subscription": "الاشتراك"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "رابط GitHub هذا طويل جدًا. إذا لم يفتح، فالرجاء فتح صفحة المشكلة ولصق السجلات يدويًا."
     }
   },
   "error": {

--- a/src/renderer/src/locales/de.json
+++ b/src/renderer/src/locales/de.json
@@ -197,7 +197,8 @@
       "subscription": "Abonnement"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Dieser GitHub-Link ist sehr lang. Wenn er sich nicht öffnet, öffnen Sie bitte die Issue-Seite und fügen Sie die Logs manuell ein."
     }
   },
   "error": {

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -131,7 +131,8 @@
     "fetch": "Fetch",
     "fetchingVideoInfo": "Fetching video info...",
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "This GitHub link is very long. If it fails to open, please open the issue page and paste the logs manually."
     },
     "history": "History",
     "imageLoadError": "Image failed to load",

--- a/src/renderer/src/locales/es.json
+++ b/src/renderer/src/locales/es.json
@@ -197,7 +197,8 @@
       "subscription": "Suscripción"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Este enlace de GitHub es muy largo. Si no se abre, abre la página de la incidencia y pega los registros manualmente."
     }
   },
   "error": {

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -197,7 +197,8 @@
       "subscription": "Abonnement"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Ce lien GitHub est très long. S'il ne s'ouvre pas, ouvrez la page de l'issue et collez les logs manuellement."
     }
   },
   "error": {

--- a/src/renderer/src/locales/id.json
+++ b/src/renderer/src/locales/id.json
@@ -197,7 +197,8 @@
       "subscription": "Berlangganan"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Tautan GitHub ini sangat panjang. Jika tidak terbuka, buka halaman issue dan tempel log secara manual."
     }
   },
   "error": {

--- a/src/renderer/src/locales/it.json
+++ b/src/renderer/src/locales/it.json
@@ -197,7 +197,8 @@
       "subscription": "Sottoscrizione"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Questo link GitHub è molto lungo. Se non si apre, apri la pagina dell'issue e incolla i log manualmente."
     }
   },
   "error": {

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -197,7 +197,8 @@
       "subscription": "サブスクリプション"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "このGitHubリンクは非常に長いです。開けない場合は、issueページを開いてログを手動で貼り付けてください。"
     }
   },
   "error": {

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -197,7 +197,8 @@
       "subscription": "신청"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "이 GitHub 링크가 매우 깁니다. 열리지 않으면 이슈 페이지를 열고 로그를 수동으로 붙여 넣어 주세요."
     }
   },
   "error": {

--- a/src/renderer/src/locales/pt.json
+++ b/src/renderer/src/locales/pt.json
@@ -197,7 +197,8 @@
       "subscription": "Subscrição"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Este link do GitHub é muito longo. Se não abrir, abra a página da issue e cole os logs manualmente."
     }
   },
   "error": {

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -197,7 +197,8 @@
       "subscription": "Подписка"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "Эта ссылка GitHub очень длинная. Если она не открывается, откройте страницу issue и вставьте логи вручную."
     }
   },
   "error": {

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -197,7 +197,8 @@
       "subscription": "訂閱"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "這個 GitHub 連結很長。如果無法開啟，請開啟 issue 頁面並手動貼上日誌。"
     }
   },
   "error": {

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -197,7 +197,8 @@
       "subscription": "订阅"
     },
     "feedback": {
-      "title": "Report this error:"
+      "title": "Report this error:",
+      "githubUrlTooLong": "这个 GitHub 链接很长。如果无法打开，请打开 issue 页面并手动粘贴日志。"
     }
   },
   "error": {


### PR DESCRIPTION
Adds a toast warning when the GitHub issue URL is very long and may fail to open. Adds localized copy for the warning.