### PR TITLE
fix(settings): add Windows-only cookies note

### DIFF
--- a/src/renderer/src/locales/ar.json
+++ b/src/renderer/src/locales/ar.json
@@ -371,6 +371,7 @@
     "audio": "تفضيلات الصوت",
     "browserForCookies": "اختر المتصفح لاستخدام ملفات تعريف الارتباط منه",
     "browserForCookiesDescription": "المتصفح لاستخراج ملفات تعريف الارتباط منه للمصادقة",
+    "browserForCookiesWindowsNote": "في Windows، يتم دعم ملفات تعريف الارتباط من Firefox فقط. للمتصفحات الأخرى، يرجى إعداد ملف ملفات تعريف الارتباط يدويًا.",
     "browserForCookiesProfile": "اسم الملف الشخصي أو المسار",
     "browserForCookiesProfileDescription": "مسار الملف الشخصي للمتصفح المحدد أعلاه. يُملأ تلقائيًا عند الإمكان.",
     "browserForCookiesProfilePlaceholder": "اسم الملف الشخصي أو المسار الكامل (اختياري)",

--- a/src/renderer/src/locales/de.json
+++ b/src/renderer/src/locales/de.json
@@ -371,6 +371,7 @@
     "audio": "Audio-Einstellungen",
     "browserForCookies": "Browser für Cookies auswählen",
     "browserForCookiesDescription": "Browser zum Extrahieren von Cookies für die Authentifizierung",
+    "browserForCookiesWindowsNote": "Unter Windows werden nur Firefox-Cookies unterstützt. Für andere Browser richten Sie bitte manuell eine Cookie-Datei ein.",
     "browserForCookiesProfile": "Profilname oder Pfad",
     "browserForCookiesProfileDescription": "Profilpfad für den oben ausgewählten Browser. Wird wenn möglich automatisch ausgefüllt.",
     "browserForCookiesProfilePlaceholder": "Profilname oder vollständiger Pfad (optional)",

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -371,6 +371,7 @@
     "audio": "Audio Preferences",
     "browserForCookies": "Select browser to use cookies from",
     "browserForCookiesDescription": "Browser to extract cookies from for authentication. We'll try to detect a profile automatically.",
+    "browserForCookiesWindowsNote": "Windows only supports Firefox cookies. For other browsers, please configure a cookies file manually.",
     "browserForCookiesProfile": "Profile name or path",
     "browserForCookiesProfileDescription": "Profile path for the browser selected above. Auto-filled when possible.",
     "browserForCookiesProfilePlaceholder": "Profile name or full path (optional)",

--- a/src/renderer/src/locales/es.json
+++ b/src/renderer/src/locales/es.json
@@ -371,6 +371,7 @@
     "audio": "Preferencias de Audio",
     "browserForCookies": "Seleccionar navegador para usar cookies",
     "browserForCookiesDescription": "Navegador del que extraer cookies para autenticación",
+    "browserForCookiesWindowsNote": "Windows solo admite cookies de Firefox. Para otros navegadores, configura manualmente un archivo de cookies.",
     "browserForCookiesProfile": "Nombre de perfil o ruta",
     "browserForCookiesProfileDescription": "Ruta del perfil para el navegador seleccionado arriba. Se completa automáticamente cuando es posible.",
     "browserForCookiesProfilePlaceholder": "Nombre de perfil o ruta completa (opcional)",

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -371,6 +371,7 @@
     "audio": "Préférences Audio",
     "browserForCookies": "Sélectionner le navigateur pour utiliser les cookies",
     "browserForCookiesDescription": "Navigateur pour extraire les cookies pour l'authentification",
+    "browserForCookiesWindowsNote": "Sous Windows, seuls les cookies de Firefox sont pris en charge. Pour les autres navigateurs, configurez un fichier de cookies manuellement.",
     "browserForCookiesProfile": "Nom du profil ou chemin",
     "browserForCookiesProfileDescription": "Chemin du profil pour le navigateur sélectionné ci-dessus. Rempli automatiquement si possible.",
     "browserForCookiesProfilePlaceholder": "Nom du profil ou chemin complet (facultatif)",

--- a/src/renderer/src/locales/id.json
+++ b/src/renderer/src/locales/id.json
@@ -371,6 +371,7 @@
     "audio": "Preferensi Audio",
     "browserForCookies": "Pilih browser untuk menggunakan cookie",
     "browserForCookiesDescription": "Browser untuk mengekstrak cookie untuk autentikasi",
+    "browserForCookiesWindowsNote": "Di Windows, hanya cookie Firefox yang didukung. Untuk browser lain, silakan konfigurasi file cookie secara manual.",
     "browserForCookiesProfile": "Nama profil atau path",
     "browserForCookiesProfileDescription": "Path profil untuk browser yang dipilih di atas. Diisi otomatis bila memungkinkan.",
     "browserForCookiesProfilePlaceholder": "Nama profil atau path lengkap (opsional)",

--- a/src/renderer/src/locales/it.json
+++ b/src/renderer/src/locales/it.json
@@ -371,6 +371,7 @@
     "audio": "Preferenze Audio",
     "browserForCookies": "Seleziona browser per usare i cookie",
     "browserForCookiesDescription": "Browser per estrarre i cookie per l'autenticazione",
+    "browserForCookiesWindowsNote": "Su Windows sono supportati solo i cookie di Firefox. Per altri browser, configura manualmente un file di cookie.",
     "browserForCookiesProfile": "Nome profilo o percorso",
     "browserForCookiesProfileDescription": "Percorso del profilo per il browser selezionato sopra. Compilato automaticamente quando possibile.",
     "browserForCookiesProfilePlaceholder": "Nome profilo o percorso completo (opzionale)",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -371,6 +371,7 @@
     "audio": "オーディオ設定",
     "browserForCookies": "Cookieに使用するブラウザを選択",
     "browserForCookiesDescription": "認証用のCookieを抽出するブラウザ",
+    "browserForCookiesWindowsNote": "Windows では Firefox の Cookie のみ対応しています。他のブラウザは Cookie ファイルを手動で設定してください。",
     "browserForCookiesProfile": "プロファイル名またはパス",
     "browserForCookiesProfileDescription": "上で選択したブラウザのプロファイルパス。可能な場合は自動入力されます。",
     "browserForCookiesProfilePlaceholder": "プロファイル名または完全なパス（任意）",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -371,6 +371,7 @@
     "audio": "오디오 환경설정",
     "browserForCookies": "쿠키를 사용할 브라우저 선택",
     "browserForCookiesDescription": "인증을 위한 쿠키 추출 브라우저",
+    "browserForCookiesWindowsNote": "Windows에서는 Firefox 쿠키만 지원됩니다. 다른 브라우저는 쿠키 파일을 수동으로 설정하세요.",
     "browserForCookiesProfile": "프로필 이름 또는 경로",
     "browserForCookiesProfileDescription": "위에서 선택한 브라우저의 프로필 경로입니다. 가능하면 자동으로 채워집니다.",
     "browserForCookiesProfilePlaceholder": "프로필 이름 또는 전체 경로(선택 사항)",

--- a/src/renderer/src/locales/pt.json
+++ b/src/renderer/src/locales/pt.json
@@ -371,6 +371,7 @@
     "audio": "Preferências de Áudio",
     "browserForCookies": "Selecionar navegador para usar cookies",
     "browserForCookiesDescription": "Navegador para extrair cookies para autenticação",
+    "browserForCookiesWindowsNote": "No Windows, apenas cookies do Firefox são suportados. Para outros navegadores, configure um arquivo de cookies manualmente.",
     "browserForCookiesProfile": "Nome do perfil ou caminho",
     "browserForCookiesProfileDescription": "Caminho do perfil para o navegador selecionado acima. Preenchido automaticamente quando possível.",
     "browserForCookiesProfilePlaceholder": "Nome do perfil ou caminho completo (opcional)",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -371,6 +371,7 @@
     "audio": "Настройки аудио",
     "browserForCookies": "Выбрать браузер для использования cookie",
     "browserForCookiesDescription": "Браузер для извлечения cookie для аутентификации",
+    "browserForCookiesWindowsNote": "В Windows поддерживаются только cookie Firefox. Для других браузеров вручную укажите файл cookie.",
     "browserForCookiesProfile": "Имя профиля или путь",
     "browserForCookiesProfileDescription": "Путь профиля для выбранного выше браузера. Заполняется автоматически, если возможно.",
     "browserForCookiesProfilePlaceholder": "Имя профиля или полный путь (необязательно)",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -371,6 +371,7 @@
     "audio": "音訊偏好",
     "browserForCookies": "選擇用於讀取 Cookie 的瀏覽器",
     "browserForCookiesDescription": "用於身份驗證的瀏覽器 Cookie 提取",
+    "browserForCookiesWindowsNote": "Windows 僅支援 Firefox 的 cookie，其他瀏覽器請手動設定 cookie 檔案。",
     "browserForCookiesProfile": "設定檔名稱或路徑",
     "browserForCookiesProfileDescription": "上方選取之瀏覽器的設定檔路徑。如可用將自動填入。",
     "browserForCookiesProfilePlaceholder": "設定檔名稱或完整路徑（選填）",

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -371,6 +371,7 @@
     "audio": "音频偏好",
     "browserForCookies": "选择用于读取 Cookie 的浏览器",
     "browserForCookiesDescription": "用于身份验证的浏览器 Cookie 提取",
+    "browserForCookiesWindowsNote": "Windows 仅支持 Firefox 的 cookie，其他浏览器请手动配置 cookie 文件。",
     "browserForCookiesProfile": "配置文件名称或路径",
     "browserForCookiesProfileDescription": "上方所选浏览器的配置文件路径。如可用会自动填写。",
     "browserForCookiesProfilePlaceholder": "配置文件名称或完整路径（可选）",

--- a/src/renderer/src/pages/Settings.tsx
+++ b/src/renderer/src/pages/Settings.tsx
@@ -676,6 +676,9 @@ export function Settings() {
                 <ItemContent>
                   <ItemTitle>{t('settings.browserForCookies')}</ItemTitle>
                   <ItemDescription>{t('settings.browserForCookiesDescription')}</ItemDescription>
+                  {platform === 'win32' && (
+                    <ItemDescription>{t('settings.browserForCookiesWindowsNote')}</ItemDescription>
+                  )}
                 </ItemContent>
                 <ItemActions>
                   {(() => {


### PR DESCRIPTION
Show the Firefox-only cookies note on Windows only. Add translations for the new Windows-specific message across locales.