### PR TITLE
fix(ci): skip PR comment trigger

### DIFF
--- a/.github/workflows/translator.yaml
+++ b/.github/workflows/translator.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   translate:
+    if: ${{ !github.event.issue.pull_request }}
     permissions:
       issues: write
       discussions: write


### PR DESCRIPTION
Avoid running translator workflow on PR comments by filtering out pull_request issues.