### PR TITLE
fix(issue-template): reorder bug report fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,21 @@ title: "[Bug]: "
 labels:
   - bug
 body:
+  - type: textarea
+    id: actual
+    attributes:
+      label: Observed behavior and screenshots
+      placeholder: What actually happened
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or add screenshots
+      placeholder: Attach files or paste logs here
+    validations:
+      required: false
   - type: input
     id: app_version
     attributes:
@@ -20,18 +35,3 @@ body:
       placeholder: macOS 14.2
     validations:
       required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: Observed behavior
-      placeholder: What actually happened
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: Logs or screenshots
-      description: Paste relevant logs or add screenshots
-      placeholder: Attach files or paste logs here
-    validations:
-      required: false


### PR DESCRIPTION
This PR updates the bug issue template field layout.\n\nIt renames the behavior label to "Observed behavior and screenshots" and moves App version and OS version below the behavior/log sections.\n\nThis keeps the report flow focused on user-facing evidence first.