### PR TITLE
fix(download): mitigate YouTube SABR failures

### DIFF
--- a/src/main/download-engine/args-builder.ts
+++ b/src/main/download-engine/args-builder.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import type { AppSettings, DownloadOptions } from '../../shared/types'
+import { appendYouTubeSafeExtractorArgs } from '../lib/youtube-extractor-args'
 import { resolvePathWithHome } from '../utils/path-helpers'
 
 export const sanitizeFilenameTemplate = (template: string): string => {
@@ -169,6 +170,8 @@ export const buildDownloadArgs = (
   const configPath = resolvePathWithHome(settings.configPath)
   if (configPath) {
     args.push('--config-location', configPath)
+  } else {
+    appendYouTubeSafeExtractorArgs(args, options.url)
   }
 
   if (jsRuntimeArgs.length > 0) {

--- a/src/main/lib/command-utils.ts
+++ b/src/main/lib/command-utils.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type { settingsManager } from '../settings'
 import { resolvePathWithHome } from '../utils/path-helpers'
+import { appendYouTubeSafeExtractorArgs } from './youtube-extractor-args'
 import { ytdlpManager } from './ytdlp-manager'
 
 export const formatYtDlpCommand = (args: string[]): string => {
@@ -58,6 +59,8 @@ export const buildVideoInfoArgs = (
   const configPath = resolvePathWithHome(settings.configPath)
   if (configPath) {
     args.push('--config-location', configPath)
+  } else {
+    appendYouTubeSafeExtractorArgs(args, url)
   }
 
   appendJsRuntimeArgs(args)

--- a/src/main/lib/download-engine.ts
+++ b/src/main/lib/download-engine.ts
@@ -47,6 +47,7 @@ import {
 } from './path-resolver'
 import { clampPercent, estimateProgressParts, isMuxedFormat } from './progress-utils'
 import { applyShareWatermark } from './watermark-utils'
+import { appendYouTubeSafeExtractorArgs } from './youtube-extractor-args'
 import { ytdlpManager } from './ytdlp-manager'
 
 interface DownloadProcess {
@@ -259,6 +260,8 @@ class DownloadEngine extends EventEmitter {
     const configPath = resolvePathWithHome(settings.configPath)
     if (configPath) {
       args.push('--config-location', configPath)
+    } else {
+      appendYouTubeSafeExtractorArgs(args, url)
     }
 
     appendJsRuntimeArgs(args)

--- a/src/main/lib/youtube-extractor-args.ts
+++ b/src/main/lib/youtube-extractor-args.ts
@@ -1,0 +1,21 @@
+const YOUTUBE_HOST_SUFFIXES = ['youtube.com', 'youtu.be', 'youtube-nocookie.com'] as const
+const YOUTUBE_SAFE_PLAYER_CLIENTS = 'default,-web,-web_safari'
+
+const hasYouTubeHost = (host: string): boolean =>
+  YOUTUBE_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))
+
+export const isYouTubeUrl = (url: string): boolean => {
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    return hasYouTubeHost(host)
+  } catch {
+    return false
+  }
+}
+
+export const appendYouTubeSafeExtractorArgs = (args: string[], url: string): void => {
+  if (!isYouTubeUrl(url)) {
+    return
+  }
+  args.push('--extractor-args', `youtube:player_client=${YOUTUBE_SAFE_PLAYER_CLIENTS}`)
+}


### PR DESCRIPTION
This PR mitigates YouTube download failures related to SABR and missing impersonation targets.
It adds a small helper that detects YouTube URLs and appends a safer extractor-args player client set.
The helper is applied consistently for video info, playlist info, and download command construction.
For users with custom yt-dlp config files, existing config behavior is preserved.

Closes #113.