### PR TITLE
ci(workflows): disable extension build and allow manual release trigger

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   detect-version:
+    if: vars.ENABLE_EXTENSION_CI == 'true'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.version_check.outputs.changed }}
@@ -42,8 +43,8 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
   submit:
+    if: vars.ENABLE_EXTENSION_CI == 'true' && needs.detect-version.outputs.changed == 'true'
     needs: detect-version
-    if: needs.detect-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*.*.*
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,13 +13,8 @@ jobs:
       upload_artifacts: true
     secrets: inherit
 
-  extension:
-    uses: ./.github/workflows/extension-build.yml
-    with:
-      upload_artifacts: true
-
   release:
-    needs: [build, extension]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## Summary
- remove extension build dependency from release workflow
- add manual trigger (workflow_dispatch) for release workflow
- gate extension publish jobs behind ENABLE_EXTENSION_CI repo variable

## Validation
- pnpm run check