### PR TITLE
feat: dark switch thumb

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/switch.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/switch.tsx
@@ -16,7 +16,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-md ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        'pointer-events-none block h-4 w-4 rounded-full bg-white shadow-md ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## Why
The previous thumb was gray, making it difficult to distinguish from the similar bg-input color.


## Now
<img width="108" height="313" alt="image" src="https://github.com/user-attachments/assets/f5ab458d-0d62-4aa1-8d4f-5eb86d0feac5" />

