### PR TITLE
fix(desktop): allow selecting non-empty folders on Linux

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -36,6 +36,12 @@ log.initialize()
 // Configure logger settings
 configureLogger()
 
+if (process.platform === 'linux') {
+  // Force fallback to native GTK/KDE file dialogs when desktop portal is too old.
+  // This avoids folder selection issues on older Linux distributions.
+  app.commandLine.appendSwitch('xdg-portal-required-version', '4')
+}
+
 const RENDERER_DIST_PATH = join(import.meta.dirname, '../renderer')
 
 protocol.registerSchemesAsPrivileged([

--- a/apps/desktop/src/main/ipc/services/file-system-service.ts
+++ b/apps/desktop/src/main/ipc/services/file-system-service.ts
@@ -16,7 +16,7 @@ class FileSystemService extends IpcService {
   @IpcMethod()
   async selectDirectory(_context: IpcContext): Promise<string | null> {
     const result = await dialog.showOpenDialog({
-      properties: ['openDirectory']
+      properties: ['openDirectory', 'createDirectory']
     })
 
     if (result.canceled || result.filePaths.length === 0) {


### PR DESCRIPTION
Fixes #264 by improving Linux folder picker compatibility in desktop.

This adds a Linux-only xdg-portal-required-version=4 startup switch so Electron falls back to native GTK/KDE dialogs on older portals (for example, Ubuntu 20.04 environments).
It also updates directory selection to use openDirectory with createDirectory for better chooser behavior.
This PR only changes desktop main-process file dialog behavior and does not modify download logic.
