### PR TITLE
fix(settings): prevent profile input cursor jump

### DIFF
--- a/apps/desktop/src/renderer/src/store/settings.ts
+++ b/apps/desktop/src/renderer/src/store/settings.ts
@@ -33,11 +33,14 @@ export const loadSettingsAtom = atom(null, async (_get, set) => {
 export const saveSettingAtom = atom(
   null,
   async (get, set, update: { key: keyof AppSettings; value: AppSettings[keyof AppSettings] }) => {
+    const previousSettings = get(settingsAtom)
+    const nextSettings = { ...previousSettings, [update.key]: update.value }
+    set(settingsAtom, nextSettings)
+
     try {
       await ipcServices.settings.set(update.key, update.value)
-      const settings = get(settingsAtom)
-      set(settingsAtom, { ...settings, [update.key]: update.value })
     } catch (error) {
+      set(settingsAtom, previousSettings)
       console.error('Failed to save setting:', error)
     }
   }


### PR DESCRIPTION
## Summary
- apply optimistic local state updates in saveSettingAtom before async persistence
- rollback to previous settings when persistence fails
- remove post-save overwrite path that could race with rapid input updates

This fixes issue #265 where the Profile name or path input cursor jumped while typing.