### PR TITLE
refactor(desktop): unify bundled binary setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,28 +29,15 @@ jobs:
           - platform: windows
             os: windows-latest
             build_script: pnpm run build:win
-            ytdlp_asset: yt-dlp.exe
-            ytdlp_output: yt-dlp.exe
-            ffmpeg_url: https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-win64-gpl.zip
-            ffmpeg_inner_path: ffmpeg-master-latest-win64-gpl\bin\ffmpeg.exe
-            ffprobe_inner_path: ffmpeg-master-latest-win64-gpl\bin\ffprobe.exe
+            mac_ffmpeg_mode: native
           - platform: macos
             os: macos-latest
             build_script: pnpm run build:mac
-            ytdlp_asset: yt-dlp_macos
-            ytdlp_output: yt-dlp_macos
-            ffmpeg_arm_url: https://github.com/eko5624/mpv-mac/releases/download/2026-01-12/ffmpeg-arm64-96e8f3b8cc.zip
-            ffmpeg_x86_url: https://github.com/eko5624/mpv-mac/releases/download/2026-01-12/ffmpeg-x86_64-96e8f3b8cc.zip
-            ffmpeg_inner_path: ffmpeg/ffmpeg
-            ffprobe_inner_path: ffmpeg/ffprobe
+            mac_ffmpeg_mode: universal
           - platform: linux
             os: ubuntu-latest
             build_script: pnpm run build:linux
-            ytdlp_asset: yt-dlp
-            ytdlp_output: yt-dlp_linux
-            ffmpeg_url: https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-linux64-gpl.tar.xz
-            ffmpeg_inner_path: ffmpeg-master-latest-linux64-gpl/bin/ffmpeg
-            ffprobe_inner_path: ffmpeg-master-latest-linux64-gpl/bin/ffprobe
+            mac_ffmpeg_mode: native
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -67,104 +54,6 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install --filter ./apps/desktop...
-
-      - name: Download ffmpeg binary (Windows)
-        if: matrix.platform == 'windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $ffmpegUrl = '${{ matrix.ffmpeg_url }}'
-          Invoke-WebRequest -Uri $ffmpegUrl -OutFile ffmpeg.zip
-          Expand-Archive ffmpeg.zip -DestinationPath ffmpeg -Force
-          $source = Join-Path 'ffmpeg' '${{ matrix.ffmpeg_inner_path }}'
-          $ffprobeSource = Join-Path 'ffmpeg' '${{ matrix.ffprobe_inner_path }}'
-          $destinationDir = Join-Path 'apps/desktop/resources' 'ffmpeg'
-          New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null
-          Copy-Item -Path $source -Destination (Join-Path $destinationDir 'ffmpeg.exe') -Force
-          Copy-Item -Path $ffprobeSource -Destination (Join-Path $destinationDir 'ffprobe.exe') -Force
-          Remove-Item ffmpeg.zip -Force
-          Remove-Item ffmpeg -Recurse -Force
-
-      - name: Download ffmpeg binary (macOS)
-        if: matrix.platform == 'macos'
-        shell: bash
-        env:
-          FFMPEG_OUTPUT: ffmpeg
-          FFPROBE_OUTPUT: ffprobe
-        run: |
-          set -euo pipefail
-          curl -fL --retry 3 --retry-delay 2 --retry-connrefused "${{ matrix.ffmpeg_arm_url }}" -o ffmpeg-arm.zip
-          unzip -q ffmpeg-arm.zip -d ffmpeg-arm
-
-          curl -fL --retry 3 --retry-delay 2 --retry-connrefused "${{ matrix.ffmpeg_x86_url }}" -o ffmpeg-x86.zip
-          unzip -q ffmpeg-x86.zip -d ffmpeg-x86
-
-          arm_bin="ffmpeg-arm/${{ matrix.ffmpeg_inner_path }}"
-          x86_bin="ffmpeg-x86/${{ matrix.ffmpeg_inner_path }}"
-          arm_probe="ffmpeg-arm/${{ matrix.ffprobe_inner_path }}"
-          x86_probe="ffmpeg-x86/${{ matrix.ffprobe_inner_path }}"
-
-          if [[ ! -f "$arm_bin" ]]; then
-            arm_bin="$(find ffmpeg-arm -type f -name ffmpeg -print -quit)"
-          fi
-          if [[ ! -f "$x86_bin" ]]; then
-            x86_bin="$(find ffmpeg-x86 -type f -name ffmpeg -print -quit)"
-          fi
-          if [[ ! -f "$arm_probe" ]]; then
-            arm_probe="$(find ffmpeg-arm -type f -name ffprobe -print -quit)"
-          fi
-          if [[ ! -f "$x86_probe" ]]; then
-            x86_probe="$(find ffmpeg-x86 -type f -name ffprobe -print -quit)"
-          fi
-
-          if [[ ! -f "$arm_bin" ]]; then
-            echo "::error::Missing arm64 ffmpeg binary at $arm_bin"
-            exit 1
-          fi
-          if [[ ! -f "$x86_bin" ]]; then
-            echo "::error::Missing x86_64 ffmpeg binary at $x86_bin"
-            exit 1
-          fi
-          if [[ ! -f "$arm_probe" ]]; then
-            echo "::error::Missing arm64 ffprobe binary at $arm_probe"
-            exit 1
-          fi
-          if [[ ! -f "$x86_probe" ]]; then
-            echo "::error::Missing x86_64 ffprobe binary at $x86_probe"
-            exit 1
-          fi
-
-          mkdir -p apps/desktop/resources/ffmpeg
-          lipo -create "$arm_bin" "$x86_bin" -output "apps/desktop/resources/ffmpeg/$FFMPEG_OUTPUT"
-          lipo -create "$arm_probe" "$x86_probe" -output "apps/desktop/resources/ffmpeg/$FFPROBE_OUTPUT"
-          chmod +x "apps/desktop/resources/ffmpeg/$FFMPEG_OUTPUT" "apps/desktop/resources/ffmpeg/$FFPROBE_OUTPUT"
-          rm -rf ffmpeg-arm ffmpeg-x86 ffmpeg-arm.zip ffmpeg-x86.zip
-
-      - name: Download ffmpeg binary (Linux)
-        if: matrix.platform == 'linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -fL --retry 3 --retry-delay 2 --retry-connrefused "${{ matrix.ffmpeg_url }}" -o ffmpeg.tar.xz
-          if ! tar -tf ffmpeg.tar.xz >/dev/null 2>&1; then
-            echo "::error::Downloaded ffmpeg archive is not a valid tar.xz"
-            exit 1
-          fi
-          mkdir ffmpeg
-          tar -xf ffmpeg.tar.xz -C ffmpeg
-          mkdir -p apps/desktop/resources/ffmpeg
-          cp "ffmpeg/${{ matrix.ffmpeg_inner_path }}" "apps/desktop/resources/ffmpeg/ffmpeg"
-          cp "ffmpeg/${{ matrix.ffprobe_inner_path }}" "apps/desktop/resources/ffmpeg/ffprobe"
-          chmod +x "apps/desktop/resources/ffmpeg/ffmpeg" "apps/desktop/resources/ffmpeg/ffprobe"
-          rm -rf ffmpeg.tar.xz ffmpeg
-
-      - name: Download yt-dlp binary
-        shell: bash
-        run: |
-          curl -fL --retry 3 --retry-delay 2 --retry-connrefused "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${{ matrix.ytdlp_asset }}" -o "apps/desktop/resources/${{ matrix.ytdlp_output }}"
-          if [[ "${{ matrix.platform }}" == "linux" ]] || [[ "${{ matrix.platform }}" == "macos" ]]; then
-            chmod +x "apps/desktop/resources/${{ matrix.ytdlp_output }}"
-          fi
 
       - name: Lint and format check
         run: pnpm run check && pnpm run typecheck
@@ -212,6 +101,8 @@ jobs:
           echo "SIGNING_AVAILABLE=true" >> "$GITHUB_ENV"
 
       - name: Build application
+        env:
+          VIDBEE_MAC_FFMPEG_MODE: ${{ matrix.mac_ffmpeg_mode }}
         run: ${{ matrix.build_script }}
 
       - name: Verify macOS codesign and notarization

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ apps/desktop/src/
 - Build production bundles with `pnpm build`.
 - Create platform-specific artifacts with `pnpm build:win`, `pnpm build:mac`, or `pnpm build:linux`.
 - Use `pnpm build:unpack` to generate unpacked directories under `apps/desktop/dist/` for manual inspection.
-- Bundle platform binaries of `yt-dlp` and `ffmpeg/ffprobe` under `apps/desktop/resources/ffmpeg/` (or set `YTDLP_PATH`/`FFMPEG_PATH`) before packaging so merges and audio extraction work out of the box.
+- Bundle `yt-dlp` under `apps/desktop/resources/` and `ffmpeg/ffprobe` under `apps/desktop/resources/ffmpeg/` before packaging so merges and audio extraction work out of the box.
 
 ## Working on Changes
 - Keep each pull request focused on a single problem or feature.

--- a/apps/desktop/scripts/setup-dev-binaries.js
+++ b/apps/desktop/scripts/setup-dev-binaries.js
@@ -20,6 +20,7 @@ const RESOURCES_DIR = path.join(currentDirPath, '..', 'resources')
 const FFMPEG_DIR = path.join(RESOURCES_DIR, 'ffmpeg')
 const YTDLP_BASE_URL = 'https://github.com/yt-dlp/yt-dlp/releases/latest/download'
 const DENO_BASE_URL = 'https://github.com/denoland/deno/releases/latest/download'
+const MAC_FFMPEG_MODE = (process.env.VIDBEE_MAC_FFMPEG_MODE || 'native').trim().toLowerCase()
 const GITHUB_TOKEN =
   process.env.GITHUB_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_API_TOKEN
 
@@ -331,6 +332,27 @@ function fileExists(filePath) {
   return fs.existsSync(filePath)
 }
 
+function findFirstFileByName(dirPath, fileName) {
+  if (!fileExists(dirPath)) {
+    return null
+  }
+
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = path.join(dirPath, entry.name)
+    if (entry.isFile() && entry.name === fileName) {
+      return fullPath
+    }
+    if (entry.isDirectory()) {
+      const found = findFirstFileByName(fullPath, fileName)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return null
+}
+
 function formatBytes(bytes) {
   if (!bytes || bytes <= 0) {
     return 'unknown size'
@@ -392,6 +414,88 @@ function getDenoAssetName(platform, arch) {
 
 function getDenoOutputName(platform) {
   return platform === 'win32' ? 'deno.exe' : 'deno'
+}
+
+function getMacFfmpegMode() {
+  if (MAC_FFMPEG_MODE === 'native' || MAC_FFMPEG_MODE === 'universal') {
+    return MAC_FFMPEG_MODE
+  }
+
+  throw new Error(
+    `Unsupported VIDBEE_MAC_FFMPEG_MODE value "${MAC_FFMPEG_MODE}". Expected "native" or "universal".`
+  )
+}
+
+function hasRequiredMacArchitectures(filePath, expectedArchitectures) {
+  const result = spawnSync('lipo', ['-archs', filePath], {
+    encoding: 'utf8'
+  })
+
+  if (result.error) {
+    throw new Error(`Failed to inspect Mach-O architectures: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim()
+    throw new Error(
+      `Failed to inspect Mach-O architectures: ${output || `exit code ${result.status}`}`
+    )
+  }
+
+  const availableArchitectures = result.stdout
+    .trim()
+    .split(/\s+/)
+    .filter((value) => value.length > 0)
+
+  return expectedArchitectures.every((architecture) =>
+    availableArchitectures.includes(architecture)
+  )
+}
+
+function runCommandOrThrow(command, args, label) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8'
+  })
+
+  if (result.error) {
+    throw new Error(`${label} failed: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim()
+    throw new Error(`${label} failed: ${output || `exit code ${result.status}`}`)
+  }
+}
+
+function resolveMacExtractedBinary(extractDir, expectedInnerPath, binaryName) {
+  const expectedPath = path.join(extractDir, expectedInnerPath)
+  if (fileExists(expectedPath)) {
+    return expectedPath
+  }
+
+  const discoveredPath = findFirstFileByName(extractDir, binaryName)
+  if (discoveredPath) {
+    return discoveredPath
+  }
+
+  throw new Error(`${binaryName} binary not found under ${extractDir}`)
+}
+
+async function resolveMacFfmpegDownloadUrl(ffmpegConfig) {
+  let downloadUrl = ffmpegConfig.url
+
+  if (ffmpegConfig.release) {
+    try {
+      const resolved = await resolveReleaseAsset(ffmpegConfig.release)
+      if (resolved) {
+        downloadUrl = resolved.url
+      }
+    } catch (error) {
+      log(`Failed to resolve latest ffmpeg asset: ${error.message}`, 'warn')
+    }
+  }
+
+  return downloadUrl
 }
 
 // Main download functions
@@ -530,21 +634,16 @@ async function downloadFfmpegWindows(config) {
 }
 
 async function downloadFfmpegMac(config) {
-  const arch = os.arch()
-  const ffmpegConfig = config.ffmpeg[arch === 'arm64' ? 'arm64' : 'x64']
+  const mode = getMacFfmpegMode()
+  const currentArchitecture = os.arch() === 'arm64' ? 'arm64' : 'x64'
+  const targetArchitectures = mode === 'universal' ? ['arm64', 'x64'] : [currentArchitecture]
 
+  const ffmpegConfig = config.ffmpeg[targetArchitectures[0]]
   if (!ffmpegConfig) {
-    throw new Error(`Unsupported architecture: ${arch}`)
+    throw new Error(`Unsupported architecture: ${currentArchitecture}`)
   }
 
-  const {
-    url: fallbackUrl,
-    innerPath,
-    ffprobeInnerPath,
-    output,
-    ffprobeOutput,
-    release
-  } = ffmpegConfig
+  const { output, ffprobeOutput } = ffmpegConfig
   const outputPath = path.join(FFMPEG_DIR, output)
   const ffprobeOutputPath = ffprobeOutput ? path.join(FFMPEG_DIR, ffprobeOutput) : null
 
@@ -556,71 +655,141 @@ async function downloadFfmpegMac(config) {
     const ffprobeValidation = ffprobeOutputPath
       ? checkBinary(ffprobeOutputPath, ['-version'], 'ffprobe')
       : { ok: true }
-    if (validation.ok && ffprobeValidation.ok) {
-      log('ffmpeg and ffprobe already exist, skipping download', 'info')
+
+    let hasExpectedArchitectures = true
+    if (mode === 'universal' && ffprobeOutputPath) {
+      try {
+        hasExpectedArchitectures =
+          hasRequiredMacArchitectures(outputPath, ['arm64', 'x86_64']) &&
+          hasRequiredMacArchitectures(ffprobeOutputPath, ['arm64', 'x86_64'])
+      } catch (error) {
+        hasExpectedArchitectures = false
+        log(`Failed to validate existing universal ffmpeg binaries: ${error.message}`, 'warn')
+      }
+    }
+
+    if (validation.ok && ffprobeValidation.ok && hasExpectedArchitectures) {
+      log(
+        `ffmpeg and ffprobe already exist for macOS (${mode === 'universal' ? 'universal' : currentArchitecture}), skipping download`,
+        'info'
+      )
       return
     }
+
     log(
       `Existing ffmpeg/ffprobe failed version check: ${validation.message || ffprobeValidation.message}`,
       'warn'
     )
   }
 
-  log(`Downloading ffmpeg for macOS (${arch})...`, 'download')
+  log(
+    `Downloading ffmpeg for macOS (${mode === 'universal' ? 'universal' : currentArchitecture})...`,
+    'download'
+  )
   ensureDir(FFMPEG_DIR)
-  const tempZip = path.join(RESOURCES_DIR, 'ffmpeg-temp.zip')
-  const extractDir = path.join(RESOURCES_DIR, 'ffmpeg-temp')
-  let downloadUrl = fallbackUrl
-
-  if (release) {
-    try {
-      const resolved = await resolveReleaseAsset(release)
-      if (resolved) {
-        downloadUrl = resolved.url
-      }
-    } catch (error) {
-      log(`Failed to resolve latest ffmpeg asset: ${error.message}`, 'warn')
-    }
-  }
+  const tempArtifacts = targetArchitectures.map((targetArchitecture) => ({
+    key: targetArchitecture,
+    tempZip: path.join(RESOURCES_DIR, `ffmpeg-${targetArchitecture}.zip`),
+    extractDir: path.join(RESOURCES_DIR, `ffmpeg-${targetArchitecture}`)
+  }))
 
   try {
-    await downloadFileWithRetry(downloadUrl, tempZip)
-    log('Extracting ffmpeg...', 'info')
-    extractZip(tempZip, extractDir)
+    const resolvedBinaries = []
 
-    const sourcePath = path.join(extractDir, innerPath)
-    if (!fileExists(sourcePath)) {
-      throw new Error(`ffmpeg binary not found at ${sourcePath}`)
+    for (const targetArchitecture of targetArchitectures) {
+      const targetConfig = config.ffmpeg[targetArchitecture]
+      if (!targetConfig) {
+        throw new Error(`Unsupported macOS ffmpeg architecture: ${targetArchitecture}`)
+      }
+
+      const tempArtifact = tempArtifacts.find((artifact) => artifact.key === targetArchitecture)
+      if (!tempArtifact) {
+        throw new Error(`Temporary artifact not configured for ${targetArchitecture}`)
+      }
+
+      const downloadUrl = await resolveMacFfmpegDownloadUrl(targetConfig)
+      await downloadFileWithRetry(downloadUrl, tempArtifact.tempZip)
+      log(`Extracting ffmpeg for macOS (${targetArchitecture})...`, 'info')
+      extractZip(tempArtifact.tempZip, tempArtifact.extractDir)
+
+      resolvedBinaries.push({
+        ffmpegPath: resolveMacExtractedBinary(
+          tempArtifact.extractDir,
+          targetConfig.innerPath,
+          'ffmpeg'
+        ),
+        ffprobePath: resolveMacExtractedBinary(
+          tempArtifact.extractDir,
+          targetConfig.ffprobeInnerPath,
+          'ffprobe'
+        )
+      })
     }
 
-    fs.copyFileSync(sourcePath, outputPath)
-    setExecutable(outputPath)
-    if (ffprobeInnerPath && ffprobeOutputPath) {
-      const ffprobeSourcePath = path.join(extractDir, ffprobeInnerPath)
-      if (!fileExists(ffprobeSourcePath)) {
-        throw new Error(`ffprobe binary not found at ${ffprobeSourcePath}`)
+    if (mode === 'universal') {
+      if (!ffprobeOutputPath) {
+        throw new Error('Universal macOS ffprobe output path is required.')
       }
-      fs.copyFileSync(ffprobeSourcePath, ffprobeOutputPath)
+
+      runCommandOrThrow(
+        'lipo',
+        ['-create', ...resolvedBinaries.map((binary) => binary.ffmpegPath), '-output', outputPath],
+        'Creating universal ffmpeg binary'
+      )
+      runCommandOrThrow(
+        'lipo',
+        [
+          '-create',
+          ...resolvedBinaries.map((binary) => binary.ffprobePath),
+          '-output',
+          ffprobeOutputPath
+        ],
+        'Creating universal ffprobe binary'
+      )
+    } else {
+      fs.copyFileSync(resolvedBinaries[0].ffmpegPath, outputPath)
+      if (ffprobeOutputPath) {
+        fs.copyFileSync(resolvedBinaries[0].ffprobePath, ffprobeOutputPath)
+      }
+    }
+
+    setExecutable(outputPath)
+    if (ffprobeOutputPath) {
       setExecutable(ffprobeOutputPath)
     }
+
     const validation = checkBinary(outputPath, ['-version'], 'ffmpeg')
     if (!validation.ok) {
       safeUnlink(outputPath)
+      safeUnlink(ffprobeOutputPath)
       throw new Error(`Downloaded ${output} failed version check: ${validation.message}`)
     }
-    log(`Downloaded ${output} successfully`, 'success')
 
-    // Cleanup
-    fs.unlinkSync(tempZip)
-    fs.rmSync(extractDir, { recursive: true, force: true })
+    if (mode === 'universal' && ffprobeOutputPath) {
+      const isUniversal =
+        hasRequiredMacArchitectures(outputPath, ['arm64', 'x86_64']) &&
+        hasRequiredMacArchitectures(ffprobeOutputPath, ['arm64', 'x86_64'])
+      if (!isUniversal) {
+        safeUnlink(outputPath)
+        safeUnlink(ffprobeOutputPath)
+        throw new Error(
+          'Created macOS ffmpeg binaries are missing required universal architectures.'
+        )
+      }
+    }
+
+    log(`Downloaded ${output} successfully`, 'success')
   } catch (error) {
-    if (fs.existsSync(tempZip)) {
-      fs.unlinkSync(tempZip)
-    }
-    if (fs.existsSync(extractDir)) {
-      fs.rmSync(extractDir, { recursive: true, force: true })
-    }
+    safeUnlink(outputPath)
+    safeUnlink(ffprobeOutputPath)
     throw error
+  } finally {
+    for (const tempArtifact of tempArtifacts) {
+      safeUnlink(tempArtifact.tempZip)
+      if (fs.existsSync(tempArtifact.extractDir)) {
+        fs.rmSync(tempArtifact.extractDir, { recursive: true, force: true })
+      }
+    }
   }
 }
 

--- a/apps/desktop/src/main/lib/database/schema.ts
+++ b/apps/desktop/src/main/lib/database/schema.ts
@@ -56,4 +56,4 @@ export type SubscriptionInsert = typeof subscriptionsTable.$inferInsert
 export type SubscriptionItemRow = typeof subscriptionItemsTable.$inferSelect
 export type SubscriptionItemInsert = typeof subscriptionItemsTable.$inferInsert
 
-export { downloadHistoryTable, type DownloadHistoryInsert, type DownloadHistoryRow }
+export { type DownloadHistoryInsert, type DownloadHistoryRow, downloadHistoryTable }

--- a/apps/desktop/src/main/lib/download-engine.ts
+++ b/apps/desktop/src/main/lib/download-engine.ts
@@ -930,9 +930,9 @@ class DownloadEngine extends EventEmitter {
         const downloadedBytes = parseSizeToBytes(progress.downloaded)
         if (downloadedBytes !== undefined) {
           latestKnownSizeBytes =
-            latestKnownSizeBytes !== undefined
-              ? Math.max(latestKnownSizeBytes, downloadedBytes)
-              : downloadedBytes
+            latestKnownSizeBytes === undefined
+              ? downloadedBytes
+              : Math.max(latestKnownSizeBytes, downloadedBytes)
         }
 
         const normalizedPercent = clampPercent(progress.percent)

--- a/apps/desktop/src/main/lib/ytdlp-manager.ts
+++ b/apps/desktop/src/main/lib/ytdlp-manager.ts
@@ -16,7 +16,7 @@ class YtDlpManager {
   private jsRuntimeArgs: string[] = []
 
   async initialize(): Promise<void> {
-    this.ytdlpPath = await this.findOrDownloadYtDlp()
+    this.ytdlpPath = this.resolveBundledYtDlp()
     this.ytdlpInstance = new YTDlpWrapCtor(this.ytdlpPath)
     this.jsRuntimeArgs = this.resolveJsRuntimeArgs()
     scopedLoggers.engine.info('yt-dlp initialized at:', this.ytdlpPath)
@@ -53,7 +53,7 @@ class YtDlpManager {
     return path.join(process.resourcesPath, 'resources')
   }
 
-  private async findOrDownloadYtDlp(): Promise<string> {
+  private resolveBundledYtDlp(): string {
     const platform = os.platform()
     let bundledName: string
 
@@ -66,13 +66,7 @@ class YtDlpManager {
       bundledName = 'yt-dlp_linux'
     }
 
-    // Check environment variable first
-    if (process.env.YTDLP_PATH && fs.existsSync(process.env.YTDLP_PATH)) {
-      scopedLoggers.engine.info('Using yt-dlp from YTDLP_PATH:', process.env.YTDLP_PATH)
-      return process.env.YTDLP_PATH
-    }
-
-    // Check for bundled yt-dlp in resources directory
+    // Desktop only supports the bundled yt-dlp binary shipped in resources.
     const resourcesPath = this.getResourcesPath()
     const bundledPath = path.join(resourcesPath, bundledName)
     if (fs.existsSync(bundledPath)) {
@@ -88,42 +82,9 @@ class YtDlpManager {
       return bundledPath
     }
 
-    // Check for system-installed yt-dlp on macOS
-    if (os.platform() === 'darwin') {
-      const possiblePaths = ['/opt/homebrew/bin/yt-dlp', '/usr/local/bin/yt-dlp']
-      for (const p of possiblePaths) {
-        if (fs.existsSync(p)) {
-          scopedLoggers.engine.info('Using system yt-dlp:', p)
-          return p
-        }
-      }
-    }
-
-    // Check for system-installed yt-dlp on Linux/FreeBSD
-    if (os.platform() === 'linux' || os.platform() === 'freebsd') {
-      try {
-        const systemPath = execSync('which yt-dlp').toString().trim()
-        if (systemPath && fs.existsSync(systemPath)) {
-          scopedLoggers.engine.info('Using system yt-dlp:', systemPath)
-          return systemPath
-        }
-      } catch (_error) {
-        // yt-dlp not in PATH, continue
-      }
-    }
-
-    // At this point, no bundled/system binary found.
-    // For Windows, we do NOT download at runtime. Require bundling.
-    if (platform === 'win32') {
-      throw new Error(
-        'yt-dlp not found. Ensure resources/yt-dlp.exe is bundled in the build output.'
-      )
-    }
-
-    // For macOS/Linux, instruct user to bundle or install system yt-dlp.
-    throw new Error(
-      'yt-dlp not found. Bundle it under resources/ in the build output or install yt-dlp in system PATH.'
-    )
+    const message = `Bundled yt-dlp not found at ${bundledPath}. Ensure it is packaged in resources.`
+    scopedLoggers.engine.error(message)
+    throw new Error(message)
   }
 
   private resolveJsRuntimeArgs(): string[] {

--- a/apps/desktop/src/renderer/src/components/download/DownloadDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/download/DownloadDialog.tsx
@@ -140,11 +140,11 @@ export function DownloadDialog({
       const rawEnd = endIndex ? Math.max(Number.parseInt(endIndex, 10), parsedStart) : undefined
       const start = info.entryCount > 0 ? Math.min(parsedStart, info.entryCount) : parsedStart
       const endValue =
-        rawEnd !== undefined
-          ? info.entryCount > 0
+        rawEnd === undefined
+          ? undefined
+          : info.entryCount > 0
             ? Math.min(rawEnd, info.entryCount)
             : rawEnd
-          : undefined
       return { start, end: endValue }
     },
     [startIndex, endIndex]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@svgr/core": "^8.1.0",
+    "@svgr/plugin-jsx": "^8.1.0",
+    "electron": "^38.3.0",
     "husky": "^9.1.7"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@svgr/core':
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx':
+        specifier: ^8.1.0
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      electron:
+        specifier: ^38.3.0
+        version: 38.3.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -282,22 +291,22 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: ^16.1.4
-        version: 16.1.6(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.7
-        version: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.2.5
-        version: 14.2.5(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 14.2.5(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.1))
       fumadocs-ui:
         specifier: 16.4.7
-        version: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+        version: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 16.1.1
-        version: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.3
         version: 19.2.4
@@ -850,48 +859,56 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64-musl@2.3.13':
     resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.3.13':
     resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64-musl@2.3.13':
     resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.3.13':
     resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -1586,89 +1603,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1748,24 +1781,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -2473,56 +2510,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -2762,48 +2810,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
     resolution: {integrity: sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.15':
     resolution: {integrity: sha512-AbvmEiteEj1nf42nE8skdHv73NoR+EwXVSgPY6l39X12Ex8pzOwwfi3Kc8GAmjsnsaDEbk+aj9NyL3UeyHcTLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.15':
     resolution: {integrity: sha512-+rzMVlvVgrXtFiS+ES78yWgKqpThgV19ISKD58Ck+YO5pO5KjyxLt7AWKsWMbY0R9yBDC82w6QVGz837AKQcHg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.15':
     resolution: {integrity: sha512-fPdEy7a8eQN9qOIK3Em9D3TO1z41JScJn8yxl/76mp4sAXFDfV4YXxsiptJcOwy6bGR+70ZSwFIZhTXzQeqwQg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.15':
     resolution: {integrity: sha512-sJ4yd6iXXdlgIMfIBXuVGp/NvmviEoMVWMOAGxtxhzLPp9LOj5k0pMEMZdjeMCl4C6Up+RM8T3Zgk+BMQ0bGcQ==}
@@ -5269,48 +5325,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -8113,9 +8177,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.0.3
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)':
+  '@fumadocs/ui@16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)':
     dependencies:
-      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -8123,7 +8187,7 @@ snapshots:
       tailwind-merge: 3.5.0
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.2.0
 
   '@gar/promisify@1.1.3': {}
@@ -8349,9 +8413,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
 
-  '@next/third-parties@16.1.6(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@next/third-parties@16.1.6(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     dependencies:
-      next: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       third-party-capital: 1.0.20
 
@@ -11494,7 +11558,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.7.5
       '@orama/orama': 3.1.18
@@ -11519,7 +11583,7 @@ snapshots:
       '@tanstack/react-router': 1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react': 19.2.14
       lucide-react: 0.562.0(react@19.2.4)
-      next: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-router: 7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11527,14 +11591,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.5(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.1)):
+  fumadocs-mdx@14.2.5(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -11549,15 +11613,15 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0):
+  fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0):
     dependencies:
-      '@fumadocs/ui': 16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
+      '@fumadocs/ui': 16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.0)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11569,7 +11633,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.4.7(@tanstack/react-router@1.161.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.9.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 0.562.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -11578,7 +11642,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.2.0
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -13031,7 +13095,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -13040,7 +13104,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.1
       '@next/swc-darwin-x64': 16.1.1
@@ -14072,10 +14136,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   sumchecker@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- require Desktop to use only bundled yt-dlp binaries and log missing bundled binaries before throwing
- move Desktop binary preparation into setup, including a macOS universal ffmpeg mode for release builds
- simplify the build workflow to rely on setup instead of downloading yt-dlp and ffmpeg separately

## Testing
- pnpm run check