### PR TITLE
fix(download): resolve P0 desktop download blockers

### DIFF
--- a/apps/desktop/src/main/lib/command-utils.ts
+++ b/apps/desktop/src/main/lib/command-utils.ts
@@ -1,5 +1,6 @@
 import {
   appendYouTubeSafeExtractorArgs as appendSharedYouTubeSafeExtractorArgs,
+  buildPlaylistInfoArgs as buildSharedPlaylistInfoArgs,
   buildVideoInfoArgs as buildSharedVideoInfoArgs,
   formatYtDlpCommand,
   resolveFfmpegLocationFromPath,
@@ -42,3 +43,9 @@ export const buildVideoInfoArgs = (
   settings: ReturnType<typeof settingsManager.getAll>
 ): string[] =>
   buildSharedVideoInfoArgs(url, toSharedSettings(settings), ytdlpManager.getJsRuntimeArgs())
+
+export const buildPlaylistInfoArgs = (
+  url: string,
+  settings: ReturnType<typeof settingsManager.getAll>
+): string[] =>
+  buildSharedPlaylistInfoArgs(url, toSharedSettings(settings), ytdlpManager.getJsRuntimeArgs())

--- a/apps/desktop/src/main/lib/download-engine.ts
+++ b/apps/desktop/src/main/lib/download-engine.ts
@@ -23,10 +23,8 @@ import {
 } from '../download-engine/format-utils'
 import { settingsManager } from '../settings'
 import { scopedLoggers } from '../utils/logger'
-import { resolvePathWithHome } from '../utils/path-helpers'
 import {
-  appendJsRuntimeArgs,
-  appendYouTubeSafeExtractorArgs,
+  buildPlaylistInfoArgs,
   buildVideoInfoArgs,
   formatYtDlpCommand,
   resolveFfmpegLocation
@@ -233,37 +231,7 @@ class DownloadEngine extends EventEmitter {
   async getPlaylistInfo(url: string): Promise<PlaylistInfo> {
     const ytdlp = ytdlpManager.getInstance()
     const settings = settingsManager.getAll()
-
-    const args = ['-J', '--flat-playlist', '--no-warnings']
-
-    // Add encoding support for proper handling of non-ASCII characters
-    args.push('--encoding', 'utf-8')
-
-    // Add proxy if configured
-    if (settings.proxy) {
-      args.push('--proxy', settings.proxy)
-    }
-
-    // Add browser cookies if configured (skip if 'none')
-    if (settings.browserForCookies && settings.browserForCookies !== 'none') {
-      args.push('--cookies-from-browser', settings.browserForCookies)
-    }
-
-    const cookiesPath = settings.cookiesPath?.trim()
-    if (cookiesPath) {
-      args.push('--cookies', cookiesPath)
-    }
-
-    // Add config file if configured
-    const configPath = resolvePathWithHome(settings.configPath)
-    if (configPath) {
-      args.push('--config-location', configPath)
-    } else {
-      appendYouTubeSafeExtractorArgs(args, url)
-    }
-
-    appendJsRuntimeArgs(args)
-    args.push(url)
+    const args = buildPlaylistInfoArgs(url, settings)
 
     interface RawPlaylistEntry {
       id?: string
@@ -864,7 +832,7 @@ class DownloadEngine extends EventEmitter {
 
     let ffmpegPath: string
     try {
-      ffmpegPath = ffmpegManager.getPath()
+      ffmpegPath = await ffmpegManager.ensureInitialized()
     } catch (error) {
       const ffmpegError = error instanceof Error ? error : new Error(String(error))
       scopedLoggers.download.error('Failed to resolve ffmpeg for download ID:', id, ffmpegError)

--- a/apps/desktop/src/main/lib/ffmpeg-manager.ts
+++ b/apps/desktop/src/main/lib/ffmpeg-manager.ts
@@ -6,10 +6,31 @@ import { scopedLoggers } from '../utils/logger'
 
 class FfmpegManager {
   private ffmpegPath: string | null = null
+  private initializationPromise: Promise<string> | null = null
 
   async initialize(): Promise<void> {
-    this.ffmpegPath = await this.findFfmpegBinary()
-    scopedLoggers.engine.info('ffmpeg initialized at:', this.ffmpegPath)
+    await this.ensureInitialized()
+  }
+
+  async ensureInitialized(): Promise<string> {
+    if (this.ffmpegPath) {
+      return this.ffmpegPath
+    }
+
+    if (!this.initializationPromise) {
+      this.initializationPromise = this.findFfmpegBinary()
+        .then((ffmpegPath) => {
+          this.ffmpegPath = ffmpegPath
+          scopedLoggers.engine.info('ffmpeg initialized at:', ffmpegPath)
+          return ffmpegPath
+        })
+        .catch((error) => {
+          this.initializationPromise = null
+          throw error
+        })
+    }
+
+    return this.initializationPromise
   }
 
   getPath(): string {

--- a/packages/downloader-core/src/browser-cookies-setting.ts
+++ b/packages/downloader-core/src/browser-cookies-setting.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 export interface BrowserCookiesSetting {
   browser: string
   profile: string
@@ -28,4 +30,33 @@ export const buildBrowserCookiesSetting = (browser: string, profile: string): st
 
   const trimmedProfile = normalizeProfileInput(profile)
   return trimmedProfile ? `${trimmedBrowser}:${trimmedProfile}` : trimmedBrowser
+}
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/
+
+const toYtDlpProfile = (profile: string): string => {
+  const trimmedProfile = normalizeProfileInput(profile).replace(/[\\/]+$/g, '')
+  if (!trimmedProfile) {
+    return ''
+  }
+
+  if (path.isAbsolute(trimmedProfile) || WINDOWS_ABSOLUTE_PATH_PATTERN.test(trimmedProfile)) {
+    return path.posix.basename(trimmedProfile.replace(/\\/g, '/'))
+  }
+
+  return trimmedProfile
+}
+
+export const resolveBrowserCookiesArg = (value: string | undefined): string | undefined => {
+  const { browser, profile } = parseBrowserCookiesSetting(value)
+  if (!browser || browser === 'none') {
+    return undefined
+  }
+
+  if (browser === 'safari') {
+    return 'safari'
+  }
+
+  const ytDlpProfile = toYtDlpProfile(profile)
+  return ytDlpProfile ? `${browser}:${ytDlpProfile}` : browser
 }

--- a/packages/downloader-core/src/yt-dlp-args.ts
+++ b/packages/downloader-core/src/yt-dlp-args.ts
@@ -1,5 +1,6 @@
 import os from 'node:os'
 import path from 'node:path'
+import { resolveBrowserCookiesArg } from './browser-cookies-setting'
 
 export interface YtDlpDownloadSettings {
   downloadPath?: string
@@ -25,12 +26,7 @@ export interface YtDlpDownloadOptions {
   customFilenameTemplate?: string
 }
 
-const YOUTUBE_HOST_SUFFIXES = ['youtube.com', 'youtu.be', 'youtube-nocookie.com'] as const
-const YOUTUBE_SAFE_PLAYER_CLIENTS = 'default,-web,-web_safari'
 const DEFAULT_FILENAME_TEMPLATE = '%(title)s via VidBee.%(ext)s'
-
-const hasYouTubeHost = (host: string): boolean =>
-  YOUTUBE_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))
 
 const trim = (value?: string | null): string => value?.trim() ?? ''
 
@@ -78,18 +74,20 @@ export const sanitizeFilenameTemplate = (template: string): string => {
 export const isYouTubeUrl = (url: string): boolean => {
   try {
     const host = new URL(url).hostname.toLowerCase()
-    return hasYouTubeHost(host)
+    return (
+      host === 'youtube.com' ||
+      host.endsWith('.youtube.com') ||
+      host === 'youtu.be' ||
+      host.endsWith('.youtu.be') ||
+      host === 'youtube-nocookie.com' ||
+      host.endsWith('.youtube-nocookie.com')
+    )
   } catch {
     return false
   }
 }
 
-export const appendYouTubeSafeExtractorArgs = (args: string[], url: string): void => {
-  if (!isYouTubeUrl(url)) {
-    return
-  }
-  args.push('--extractor-args', `youtube:player_client=${YOUTUBE_SAFE_PLAYER_CLIENTS}`)
-}
+export const appendYouTubeSafeExtractorArgs = (_args: string[], _url: string): void => {}
 
 export const formatYtDlpCommand = (args: string[]): string => {
   const quoted = args.map((arg) => {
@@ -171,6 +169,9 @@ export const buildDownloadArgs = (
     const formatSelector = resolveVideoFormatSelector(options)
     if (formatSelector) {
       args.push('-f', formatSelector)
+      if (formatSelector.includes('+') && !formatSelector.includes('+none')) {
+        args.push('--merge-output-format', 'mkv')
+      }
     }
     if ((options.audioFormatIds?.length ?? 0) > 0 || formatSelector.includes('mergeall')) {
       args.push('--audio-multistreams')
@@ -223,8 +224,9 @@ export const buildDownloadArgs = (
     args.push('--windows-filenames')
   }
 
-  if (browserForCookies && browserForCookies !== 'none') {
-    args.push('--cookies-from-browser', browserForCookies)
+  const browserCookiesArg = resolveBrowserCookiesArg(settings.browserForCookies)
+  if (browserCookiesArg) {
+    args.push('--cookies-from-browser', browserCookiesArg)
   }
 
   if (cookiesPath) {
@@ -263,9 +265,9 @@ export const buildVideoInfoArgs = (
     args.push('--proxy', proxy)
   }
 
-  const browserForCookies = trim(settings.browserForCookies)
-  if (browserForCookies && browserForCookies !== 'none') {
-    args.push('--cookies-from-browser', browserForCookies)
+  const browserCookiesArg = resolveBrowserCookiesArg(settings.browserForCookies)
+  if (browserCookiesArg) {
+    args.push('--cookies-from-browser', browserCookiesArg)
   }
 
   const cookiesPath = trim(settings.cookiesPath)
@@ -300,9 +302,9 @@ export const buildPlaylistInfoArgs = (
     args.push('--proxy', proxy)
   }
 
-  const browserForCookies = trim(settings.browserForCookies)
-  if (browserForCookies && browserForCookies !== 'none') {
-    args.push('--cookies-from-browser', browserForCookies)
+  const browserCookiesArg = resolveBrowserCookiesArg(settings.browserForCookies)
+  if (browserCookiesArg) {
+    args.push('--cookies-from-browser', browserCookiesArg)
   }
 
   const cookiesPath = trim(settings.cookiesPath)


### PR DESCRIPTION
Summary
- normalize yt-dlp browser cookie arguments so Safari uses default resolution and absolute browser profile paths are serialized safely
- make ffmpeg initialization recoverable at download time so startup misses do not cause later Bilibili download failures
- default merged video downloads to MKV and remove the stale forced YouTube player client override to reduce YouTube format/merge failures
- reuse the shared playlist info argument builder in desktop flows so info fetching and downloads stay aligned

Fixes
- Fixes #294
- Fixes #257
- Fixes #232
- Fixes #207

Notes
- #168 appears to have already been addressed on `main` before this PR and is not changed by this branch

Testing
- pnpm run check