### PR TITLE
fix(download): allow choosing the playlist video container

### DIFF
--- a/apps/desktop/src/renderer/src/components/download/DownloadDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/download/DownloadDialog.tsx
@@ -9,6 +9,11 @@ import {
   buildVideoFormatPreference
 } from '@shared/utils/format-preferences'
 import { buildVideoInfoDownloadMetadata } from '@shared/utils/video-info-metadata'
+import {
+  ONE_CLICK_CONTAINER_OPTIONS,
+  type OneClickContainerOption
+} from '@vidbee/downloader-core/format-preferences'
+import { DownloadContainerSelect } from '@vidbee/ui/components/ui/download-container-select'
 import { IngestDropOverlay } from '@vidbee/ui/components/ui/ingest-drop-overlay'
 import { isPlaylistLikeUrl } from '@vidbee/ui/lib/url-kind'
 import { useAddUrlInteraction } from '@vidbee/ui/lib/use-add-url-interaction'
@@ -124,6 +129,7 @@ export function DownloadDialog({
   const advancedOptionsId = useId()
   const [playlistUrl, setPlaylistUrl] = useState('')
   const [downloadType, setDownloadType] = useState<'video' | 'audio'>('video')
+  const [playlistContainer, setPlaylistContainer] = useState<OneClickContainerOption>()
   const [startIndex, setStartIndex] = useState('1')
   const [endIndex, setEndIndex] = useState('')
   const [playlistCustomDownloadPath, setPlaylistCustomDownloadPath] = useState('')
@@ -572,7 +578,8 @@ export function DownloadDialog({
         downloadType === 'video'
           ? buildVideoFormatPreference(settings)
           : buildAudioFormatPreference(settings)
-      const containerFormat = downloadType === 'video' ? settings.oneClickContainer : undefined
+      const containerFormat =
+        downloadType === 'video' ? (playlistContainer ?? settings.oneClickContainer) : undefined
 
       const result = await ipcServices.download.startPlaylistDownload({
         url: trimmedUrl,
@@ -624,6 +631,7 @@ export function DownloadDialog({
     addDownload,
     t,
     playlistCustomDownloadPath,
+    playlistContainer,
     selectedEntryIds
   ])
 
@@ -756,6 +764,7 @@ export function DownloadDialog({
     })
 
     setPlaylistUrl('')
+    setPlaylistContainer(undefined)
     setPlaylistInfo(null)
     setPlaylistPreviewError(null)
     setPlaylistCustomDownloadPath('')
@@ -997,6 +1006,16 @@ export function DownloadDialog({
         playlistTabContent={
           <PlaylistDownload
             advancedOptionsOpen={advancedOptionsOpen}
+            containerSelect={
+              downloadType === 'video' && (
+                <DownloadContainerSelect
+                  disabled={playlistBusy}
+                  onValueChange={setPlaylistContainer}
+                  options={ONE_CLICK_CONTAINER_OPTIONS}
+                  value={playlistContainer ?? settings.oneClickContainer ?? 'auto'}
+                />
+              )
+            }
             downloadType={downloadType}
             downloadTypeId={downloadTypeId}
             endIndex={endIndex}

--- a/apps/desktop/src/renderer/src/components/download/PlaylistDownload.tsx
+++ b/apps/desktop/src/renderer/src/components/download/PlaylistDownload.tsx
@@ -6,7 +6,7 @@ import { TabItem, Tabs, TabsList } from '@renderer/components/ui/tabs'
 import { cn } from '@renderer/lib/utils'
 import type { PlaylistInfo } from '@shared/types'
 import { Loader2, Settings2 } from 'lucide-react'
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DownloadParseErrorBanner } from './DownloadParseErrorBanner'
 
@@ -19,6 +19,7 @@ interface PlaylistDownloadProps {
   selectedEntryIds: Set<string>
   downloadType: 'video' | 'audio'
   downloadTypeId: string
+  containerSelect: ReactNode
   startIndex: string
   endIndex: string
   advancedOptionsOpen: boolean
@@ -52,6 +53,7 @@ export function PlaylistDownload({
   selectedEntryIds,
   downloadType,
   downloadTypeId,
+  containerSelect,
   startIndex,
   endIndex,
   advancedOptionsOpen,
@@ -122,7 +124,7 @@ export function PlaylistDownload({
             </p>
           </div>
 
-          <div className="flex items-center gap-1.5">
+          <div className="flex flex-wrap items-center gap-1.5">
             <Tabs
               onValueChange={(value) => setDownloadType(value as 'video' | 'audio')}
               size="compact"
@@ -133,6 +135,8 @@ export function PlaylistDownload({
                 <TabItem label={t('download.audio')} value="audio" />
               </TabsList>
             </Tabs>
+
+            {containerSelect}
 
             <Button
               aria-label={t('advancedOptions.title')}

--- a/apps/web/src/components/download/download-dialog.tsx
+++ b/apps/web/src/components/download/download-dialog.tsx
@@ -3,9 +3,14 @@ import type {
 	VideoFormat,
 	VideoInfo,
 } from "@vidbee/downloader-core";
+import {
+	ONE_CLICK_CONTAINER_OPTIONS,
+	type OneClickContainerOption,
+} from "@vidbee/downloader-core/format-preferences";
 import { AddUrlPopover } from "@vidbee/ui/components/ui/add-url-popover";
 import { Button } from "@vidbee/ui/components/ui/button";
 import { Checkbox } from "@vidbee/ui/components/ui/checkbox";
+import { DownloadContainerSelect } from "@vidbee/ui/components/ui/download-container-select";
 import { DownloadDialogLayout } from "@vidbee/ui/components/ui/download-dialog-layout";
 import { IngestDropOverlay } from "@vidbee/ui/components/ui/ingest-drop-overlay";
 import { Input } from "@vidbee/ui/components/ui/input";
@@ -110,6 +115,8 @@ export function DownloadDialog({ onDownloadsChanged }: DownloadDialogProps) {
 	const advancedOptionsId = useId();
 	const [playlistUrl, setPlaylistUrl] = useState("");
 	const [downloadType, setDownloadType] = useState<"video" | "audio">("video");
+	const [playlistContainer, setPlaylistContainer] =
+		useState<OneClickContainerOption>();
 	const [startIndex, setStartIndex] = useState("1");
 	const [endIndex, setEndIndex] = useState("");
 	const [playlistInfo, setPlaylistInfo] = useState<PlaylistInfo | null>(null);
@@ -481,7 +488,9 @@ export function DownloadDialog({ onDownloadsChanged }: DownloadDialogProps) {
 					? buildVideoFormatPreference(settings)
 					: buildAudioFormatPreference(settings);
 			const containerFormat =
-				downloadType === "video" ? settings.oneClickContainer : undefined;
+				downloadType === "video"
+					? (playlistContainer ?? settings.oneClickContainer)
+					: undefined;
 
 			const result = await orpcClient.playlist.download({
 				url: trimmedUrl,
@@ -512,6 +521,7 @@ export function DownloadDialog({ onDownloadsChanged }: DownloadDialogProps) {
 		playlistUrl,
 		playlistInfo,
 		selectedEntryIds,
+		playlistContainer,
 		computePlaylistRange,
 		downloadType,
 		settings,
@@ -613,6 +623,7 @@ export function DownloadDialog({ onDownloadsChanged }: DownloadDialogProps) {
 		});
 
 		setPlaylistUrl("");
+		setPlaylistContainer(undefined);
 		setPlaylistInfo(null);
 		setPlaylistPreviewError(null);
 		setStartIndex("1");
@@ -794,6 +805,18 @@ export function DownloadDialog({ onDownloadsChanged }: DownloadDialogProps) {
 				playlistTabContent={
 					<PlaylistDownload
 						advancedOptionsOpen={advancedOptionsOpen}
+						containerSelect={
+							downloadType === "video" && (
+								<DownloadContainerSelect
+									disabled={playlistBusy}
+									onValueChange={setPlaylistContainer}
+									options={ONE_CLICK_CONTAINER_OPTIONS}
+									value={
+										playlistContainer ?? settings.oneClickContainer ?? "auto"
+									}
+								/>
+							)
+						}
 						downloadType={downloadType}
 						downloadTypeId={downloadTypeId}
 						endIndex={endIndex}

--- a/apps/web/src/components/download/playlist-download.tsx
+++ b/apps/web/src/components/download/playlist-download.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from "@vidbee/ui/components/ui/scroll-area";
 import { TabItem, Tabs, TabsList } from "@vidbee/ui/components/ui/tabs";
 import { cn } from "@vidbee/ui/lib/cn";
 import { AlertCircle, List, Loader2, Settings2 } from "lucide-react";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 
 interface PlaylistDownloadProps {
@@ -19,6 +19,7 @@ interface PlaylistDownloadProps {
 	selectedEntryIds: Set<string>;
 	downloadType: "video" | "audio";
 	downloadTypeId: string;
+	containerSelect: ReactNode;
 	startIndex: string;
 	endIndex: string;
 	advancedOptionsOpen: boolean;
@@ -52,6 +53,7 @@ export function PlaylistDownload({
 	selectedEntryIds,
 	downloadType,
 	downloadTypeId,
+	containerSelect,
 	startIndex,
 	endIndex,
 	advancedOptionsOpen,
@@ -146,7 +148,7 @@ export function PlaylistDownload({
 					</div>
 
 					<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-						<div className="flex shrink-0 items-center gap-1.5">
+						<div className="flex shrink-0 flex-wrap items-center gap-1.5">
 							<Tabs
 								onValueChange={(value) =>
 									setDownloadType(value as "video" | "audio")
@@ -162,6 +164,8 @@ export function PlaylistDownload({
 									<TabItem label={t("download.audio")} value="audio" />
 								</TabsList>
 							</Tabs>
+
+							{containerSelect}
 
 							<Button
 								aria-label={t("advancedOptions.title")}

--- a/packages/ui/src/components/ui/download-container-select.tsx
+++ b/packages/ui/src/components/ui/download-container-select.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
+
+interface DownloadContainerSelectProps<T extends string> {
+  value: T
+  options: readonly T[]
+  onValueChange: (value: T) => void
+  disabled?: boolean
+}
+
+export function DownloadContainerSelect<T extends string>({
+  value,
+  options,
+  onValueChange,
+  disabled
+}: DownloadContainerSelectProps<T>) {
+  const { t } = useTranslation()
+
+  return (
+    <Select
+      disabled={disabled}
+      onValueChange={(nextValue) => {
+        const option = options.find((candidate) => candidate === nextValue)
+        if (option !== undefined) {
+          onValueChange(option)
+        }
+      }}
+      value={value}
+    >
+      <SelectTrigger
+        aria-label={t('settings.oneClickContainer')}
+        className="h-7 w-40 rounded-md text-xs"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {t(`settings.oneClickContainerOptions.${option}`)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}


### PR DESCRIPTION
Playlist downloads currently inherit the one-click container setting without showing a container selector. This leaves users unable to choose MP4 or MKV directly when a default WebM output causes thumbnail-embedding errors, as reported in #467.

Add the existing Auto, MP4, MKV, WebM, and Original choices to the playlist dialog in both desktop and web, using a shared control and existing translations. The selection applies only to the current dialog, resets on close, and leaves global settings unchanged. It is hidden for audio downloads and disabled while the playlist is busy.

This adds the missing video-container choice. It does not add WebM thumbnail-embedding support; users who need embedded thumbnails can select MP4 or MKV.

Validation:

- `pnpm run check` passed (desktop lint, locale completeness, main and renderer typechecks).
- Targeted Biome check passed for all five changed files.
- `pnpm --filter web exec tsc --noEmit` passed.
- `pnpm --filter web run build` passed.
- Headless Chrome smoke tests against the production web build with a mocked API passed: all five choices reach the playlist request, selection resets on reopen, global settings remain unchanged, audio requests omit the video container, and the control fits a 420px viewport. No uncaught browser errors.
- Actual media downloads and an interactive Electron run were not performed.

Related to #467.