### PR TITLE
fix(transcription): prevent worker result hangs

### DIFF
--- a/packages/transcription/src/executor.ts
+++ b/packages/transcription/src/executor.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process'
-import { mkdirSync, rmSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type {
@@ -44,8 +44,10 @@ import type { PipelineResult, PipelineSegment, TranscriptionStage } from './type
 import {
   encodeMessage,
   parseMessage,
+  resultPathFor,
   type WorkerInbound,
-  type WorkerOutbound
+  type WorkerOutbound,
+  type WorkerResultFile
 } from './worker/protocol'
 
 export type TranscriptionBackend = 'sherpa' | 'fake'
@@ -455,6 +457,16 @@ export class TranscriptionExecutor implements Executor {
     existingTranscriptPath?: string
   }): Promise<{ result: PipelineResult; durationMs: number }> {
     return new Promise((resolve, reject) => {
+      const generation = `${input.ctx.attemptId}:${Date.now()}:${Math.random()}`
+      const resultPath = resultPathFor(input.workDir)
+      try {
+        unlinkSync(resultPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          reject(error)
+          return
+        }
+      }
       const child: ChildProcess = spawn(
         input.runtime.execPath,
         [...(this.opts.execArgv ?? []), this.opts.workerScript],
@@ -471,6 +483,7 @@ export class TranscriptionExecutor implements Executor {
         type: 'start',
         taskId: input.ctx.taskId,
         attemptId: input.ctx.attemptId,
+        generation,
         sourceFilePath: input.parsed.sourceFilePath,
         ffmpegPath: this.opts.resolveFfmpegPath(),
         workDir: input.workDir,
@@ -553,7 +566,34 @@ export class TranscriptionExecutor implements Executor {
               line: message.line
             })
           } else if (message.type === 'result') {
-            settle(() => resolve({ result: message.result, durationMs: message.durationMs }))
+            settle(() => {
+              try {
+                if (
+                  message.attemptId !== input.ctx.attemptId ||
+                  message.generation !== generation
+                ) {
+                  throw new Error('ai-worker returned an incompatible result notification')
+                }
+                const resultFile = JSON.parse(
+                  readFileSync(resultPath, 'utf8')
+                ) as WorkerResultFile
+                if (
+                  resultFile.attemptId !== input.ctx.attemptId ||
+                  resultFile.generation !== generation ||
+                  !resultFile.result ||
+                  typeof resultFile.durationMs !== 'number'
+                ) {
+                  throw new Error('ai-worker wrote an invalid result file')
+                }
+                resolve(resultFile)
+              } catch (error) {
+                reject(
+                  error instanceof Error
+                    ? error
+                    : new Error(`ai-worker result file could not be read: ${String(error)}`)
+                )
+              }
+            })
           } else if (message.type === 'error') {
             settle(() => {
               if (message.message === 'cancelled' || input.abort.signal.aborted) {

--- a/packages/transcription/src/pipeline-sherpa.ts
+++ b/packages/transcription/src/pipeline-sherpa.ts
@@ -343,14 +343,18 @@ export class SherpaTranscriptionPipeline implements TranscriptionPipeline {
     input: PipelineRunInput,
     manifest: ReturnType<typeof loadChunkManifest>
   ): TimedTurn[] {
-    if (manifest?.turns.length) {
-      return fillUncoveredTurns(manifest.turns, durationMs)
+    const latestManifest =
+      input.manifestPath && manifest
+        ? loadChunkManifest(input.manifestPath) ?? manifest
+        : manifest
+    if (latestManifest?.turns.length) {
+      return fillUncoveredTurns(latestManifest.turns, durationMs)
     }
     report(input, 'diarizing', 0.88)
     const turns = this.diarize(addon, wave, speech, durationMs, input)
-    if (manifest && input.manifestPath) {
-      manifest.turns = turns
-      saveChunkManifest(input.manifestPath, manifest)
+    if (latestManifest && input.manifestPath) {
+      latestManifest.turns = turns
+      saveChunkManifest(input.manifestPath, latestManifest)
     }
     return turns
   }

--- a/packages/transcription/src/worker/entry.ts
+++ b/packages/transcription/src/worker/entry.ts
@@ -4,6 +4,7 @@
  */
 import { writeSync } from 'node:fs'
 import { readAsrResult } from '../asr-json'
+import { atomicWriteJson } from '../atomic-file'
 import { tryRecognizerConfig } from '../asr-recognizer'
 import { ASR_TIER_IDS } from '../asr-tiers'
 import { extractMonoWav } from '../audio'
@@ -15,7 +16,13 @@ import { SherpaTranscriptionPipeline } from '../pipeline-sherpa'
 import { loadPipelineSeed, seedDurationMs } from '../speaker-assign'
 import { parseSpeakerCount } from '../speaker-count'
 import type { TranscriptionStage } from '../types'
-import { encodeMessage, parseMessage, type WorkerInbound, type WorkerOutbound } from './protocol'
+import {
+  encodeMessage,
+  parseMessage,
+  resultPathFor,
+  type WorkerInbound,
+  type WorkerOutbound
+} from './protocol'
 
 const send = (message: WorkerOutbound): void => {
   // writeSync so Electron-as-Node pipe buffering cannot starve the watchdog.
@@ -181,7 +188,18 @@ const handleStart = async (
         })
       }
     })
-    send({ type: 'result', result, durationMs: extracted.durationMs })
+    atomicWriteJson(resultPathFor(message.workDir), {
+      attemptId: message.attemptId,
+      generation: message.generation,
+      result,
+      durationMs: extracted.durationMs
+    })
+    send({
+      type: 'result',
+      attemptId: message.attemptId,
+      generation: message.generation,
+      durationMs: extracted.durationMs
+    })
   } catch (err) {
     const text = err instanceof Error ? err.message : String(err)
     if (signal.aborted || /cancelled/i.test(text)) {

--- a/packages/transcription/src/worker/protocol.ts
+++ b/packages/transcription/src/worker/protocol.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import type { AsrTierId } from '../asr-tiers'
 import type { SpeakerCount } from '../speaker-count'
 import type { PipelineProgress, PipelineResult, TranscriptionStage, TranscriptWord } from '../types'
@@ -6,6 +7,7 @@ export interface WorkerStartMessage {
   type: 'start'
   taskId: string
   attemptId: string
+  generation: string
   sourceFilePath: string
   ffmpegPath: string
   workDir: string
@@ -51,9 +53,19 @@ export interface WorkerPartialMessage {
 
 export interface WorkerResultMessage {
   type: 'result'
+  attemptId: string
+  generation: string
+  durationMs: number
+}
+
+export interface WorkerResultFile {
+  attemptId: string
+  generation: string
   result: PipelineResult
   durationMs: number
 }
+
+export const resultPathFor = (workDir: string): string => join(workDir, 'result.json')
 
 export interface WorkerErrorMessage {
   type: 'error'


### PR DESCRIPTION
Fixes #470.\n\n- Write the complete worker result atomically to result.json and send only a small completion notification.\n- Validate attempt/generation metadata to reject stale or incompatible results.\n- Reload the latest chunk manifest before saving diarization turns to preserve ASR chunks.